### PR TITLE
Add load-pkg to the makefile and add the development guide link to README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -312,6 +312,10 @@ DEP_CONSTRAINT ?= >= 0.0.0
 ifeq (-,$(findstring -,$(VERSION)))
     DEP_CONSTRAINT = >= 0.0.0-0
 endif
+# Define SUBPACKAGES variable and set its value from PROVIDERS
+SUBPACKAGES := $(PROVIDERS)
+# Define XPKG_REG_ORGS variable and set its value from REPO
+XPKG_REG_ORGS := $(REPO)
 load-pkg: $(UP) build.all
 	@$(INFO) Loading the family providers into the Docker daemon: $(SUBPACKAGES)
 	@for p in $(PLATFORMS); do \

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 </div>
 
-`provider-gcp` is a [Crossplane](https://crossplane.io/) provider that
+Provider GCP is a [Crossplane](https://crossplane.io/) provider that
 is built using [Upjet](https://github.com/crossplane/upjet) code
 generation tools and exposes XRM-conformant managed resources for the 
 GCP API.
@@ -43,16 +43,30 @@ Follow the guide [here](https://github.com/crossplane/upjet/blob/v0.10.0/docs/ad
 
 ### Local Development
 
-For building provider images locally, follow the guide [here](https://github.com/upbound/upjet/blob/main/docs/buliding-provider-images.md).
+1. Check out the provider repo, crossplane-contrib/provider-upjet-gcp, and go to the project
+directory on your local machine.
+
+2. Do the necessary changes locally and please make sure you have comitted all of them.
+
+3. Run the `make load-pkg` command for family providers as follows.
+
+If you want to build any of the family resource providers (e.g., `provider-gcp-cloudplatform`, `provider-gcp-container`),  you can do:
+
+```shell
+make load-pkg PROVIDERS="cloudplatform container" REPO="index.docker.io/<your-dockerhub-org>"
+```
+*Note: Installable images for the family config provider will be created by default.*
+
+For more information, follow the guide [here](https://marketplace.upbound.io/providers/upbound/provider-family-gcp/latest/docs/development).
 
 ## Report a Bug
 
 For filing bugs, suggesting improvements, or requesting new features, please
-open an [issue](https://github.com/crossplane-contrib/provider-upjet-gcp/issues).
+open an [issue](https://github.com/crossplane-contrib/provider-upjet-gcp/issues/new/choose).
 
 ## Contact
 
-[#upbound-provider-gcp](https://crossplane.slack.com/archives/C05E7EVM459) channel in
+[#upjet-provider-gcp](https://crossplane.slack.com/archives/C05E7EVM459) channel in
 [Crossplane Slack](https://slack.crossplane.io)
 
 ## Licensing

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ If you'd like to learn how to use Upjet, see [Usage Guide](https://github.com/cr
 
 Follow the guide [here](https://github.com/crossplane/upjet/blob/v0.10.0/docs/add-new-resource-short.md).
 
+### Local Development
+
+For building provider images locally, follow the guide [here](https://github.com/upbound/upjet/blob/main/docs/buliding-provider-images.md).
+
 ## Report a Bug
 
 For filing bugs, suggesting improvements, or requesting new features, please

--- a/docs/family/Development.md
+++ b/docs/family/Development.md
@@ -1,0 +1,108 @@
+---
+title: Development
+weight: 3
+---
+
+# Building the Official Provider Family Images Locally
+
+1. Check out the provider repo, crossplane-contrib/provider-upjet-gcp, and go to the project
+directory on your local machine.
+
+2. Do the necessary changes locally and please make sure you have comitted all of them.
+
+3. Run the `make load-pkg` command for family providers as follows.
+
+If you want to build any of the family resource providers (e.g., `provider-gcp-cloudplatform`, `provider-gcp-container`),  you can do:
+
+```shell
+make load-pkg PROVIDERS="cloudplatform container" REPO="index.docker.io/<your-dockerhub-org>"
+```
+*Note: Installable images for the family config provider will be created by default.*
+
+After the command is completed, you will see the installable images for `provider-gcp-cloudplatform`, `provider-gcp-container`
+and family config provider `provider-family-gcp`:
+
+```shell
+> docker image ls
+REPOSITORY                                 TAG                         IMAGE ID       CREATED        SIZE
+turkenf/provider-family-gcp-amd64          v1.1.0-rc.0.42.g42cf069b9   baac1f7e697d   6 minutes ago  179MB
+turkenf/provider-gcp-cloudplatform-amd64   v1.1.0-rc.0.42.g42cf069b9   fe2106877bf9   6 minutes ago  181MB
+turkenf/provider-gcp-container-amd64       v1.1.0-rc.0.42.g42cf069b9   94f8d11c2709   6 minutes ago  181MB
+turkenf/provider-gcp-cloudplatform-arm64   v1.1.0-rc.0.42.g42cf069b9   edbf18e9d01f   6 minutes ago  176MB
+turkenf/provider-gcp-container-arm64       v1.1.0-rc.0.42.g42cf069b9   0d3ab205ef66   6 minutes ago  176MB
+turkenf/provider-family-gcp-arm64          v1.1.0-rc.0.42.g42cf069b9   a6ef52d83555   6 minutes ago  175MB
+```
+
+## Running Providers with Locally Built Images
+
+One way to install locally built images is pushing them to Dockerhub and installing from there. For example, if you want to 
+install the `cloudplatform` package on a arm64 arch:
+
+1. Push provider images to Dockerhub:
+
+```shell
+# push the images to your dockerhub org
+docker push <your-dockerhub-org>/provider-family-gcp-arm64:v1.1.0-rc.0.42.g42cf069b9
+docker push <your-dockerhub-org>/provider-gcp-cloudplatform-arm64:v1.1.0-rc.0.42.g42cf069b9
+```
+
+2. Install the provider packages by setting `skipDependencyResolution: true` with the following yaml:
+
+```yaml
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+    name: upbound-provider-gcp-config
+spec:
+    package: index.docker.io/turkenf/provider-family-gcp-arm64:v1.1.0-rc.0.42.g42cf069b9
+    skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+    name: upbound-provider-gcp-cloudplatform
+spec:
+    package: index.docker.io/turkenf/provider-gcp-cloudplatform-arm64:v1.1.0-rc.0.42.g42cf069b9
+    skipDependencyResolution: true
+```
+
+3. Verify that providers are installed and healthy:
+
+```shell
+> kubectl get providers.pkg.crossplane.io
+NAME                                 INSTALLED   HEALTHY   PACKAGE                                                                              AGE
+upbound-provider-gcp-cloudplatform   True        True      index.docker.io/turkenf/provider-gcp-cloudplatform-arm64:v1.1.0-rc.0.42.g42cf069b9   115s
+upbound-provider-gcp-config          True        True      index.docker.io/turkenf/provider-family-gcp-arm64:v1.1.0-rc.0.42.g42cf069b9          115s
+```
+
+*Note: If you don't want to set `skipDependencyResolution: true`, please follow the steps below:*
+
+- Tag the family config provider image as provider-family-gcp
+
+```shell
+# get rid of the arch to resolve package dependencies 
+docker tag <your-dockerhub-org>/provider-family-gcp-arm64:v1.1.0-rc.0.42.g42cf069b9 <your-dockerhub-org>/provider-family-gcp:v1.1.0-rc.0.42.g42cf069b9
+# push the images to your dockerhub org
+docker push <your-dockerhub-org>/provider-family-gcp:v1.1.0-rc.0.42.g42cf069b9
+docker push <your-dockerhub-org>/provider-gcp-cloudplatform-arm64:v1.1.0-rc.0.42.g42cf069b9
+```
+
+- Install the provider package:
+
+```yaml
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+    name: upbound-provider-gcp-cloudplatform
+spec:
+    package: index.docker.io/turkenf/provider-gcp-cloudplatform-arm64:v1.1.0-rc.0.42.g42cf069b9
+```
+
+- Verify that providers are installed and healthy:
+
+```shell
+> kubectl get providers.pkg.crossplane.io
+NAME                                 INSTALLED   HEALTHY   PACKAGE                                                                              AGE
+turkenf-provider-family-gcp          True        True      index.docker.io/turkenf/provider-family-gcp:v1.1.0-rc.0.42.g42cf069b9                73s
+upbound-provider-gcp-cloudplatform   True        True      index.docker.io/turkenf/provider-gcp-cloudplatform-arm64:v1.1.0-rc.0.42.g42cf069b9   2m1s
+```


### PR DESCRIPTION
### Description of your changes

This PR adds load-pkg dev make target to the makefile.

Fixes: https://github.com/upbound/provider-gcp/issues/309

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

- Run the following command: 
```shell
make load-pkg PROVIDERS="cloudplatform container" REPO="index.docker.io/turkenf"
```
- After the above command is completed:
```shell
> docker image ls
REPOSITORY                                 TAG                         IMAGE ID       CREATED        SIZE
turkenf/provider-family-gcp-amd64          v1.1.0-rc.0.42.g42cf069b9   baac1f7e697d   6 weeks ago    179MB
turkenf/provider-gcp-cloudplatform-amd64   v1.1.0-rc.0.42.g42cf069b9   fe2106877bf9   6 weeks ago    181MB
turkenf/provider-gcp-container-amd64       v1.1.0-rc.0.42.g42cf069b9   94f8d11c2709   6 weeks ago    181MB
turkenf/provider-gcp-cloudplatform-arm64   v1.1.0-rc.0.42.g42cf069b9   edbf18e9d01f   6 weeks ago    176MB
turkenf/provider-gcp-container-arm64       v1.1.0-rc.0.42.g42cf069b9   0d3ab205ef66   6 weeks ago    176MB
turkenf/provider-family-gcp-arm64          v1.1.0-rc.0.42.g42cf069b9   a6ef52d83555   6 weeks ago    175MB
```
Installable images for the family config provider created by default.

- Manually tested and installed `config` and `cloudplatform` packages in local cluster:
 
```shell
> kubectl get providers.pkg.crossplane.io
NAME                                 INSTALLED   HEALTHY   PACKAGE                                                                              AGE
upbound-provider-gcp-cloudplatform   True        True      index.docker.io/turkenf/provider-gcp-cloudplatform-arm64:v1.1.0-rc.0.42.g42cf069b9   115s
upbound-provider-gcp-config          True        True      index.docker.io/turkenf/provider-family-gcp-arm64:v1.1.0-rc.0.42.g42cf069b9          115s
```
