### PR TITLE
Switch to Github hosted runners for the CI jobs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -12,4 +12,4 @@ on:
 
 jobs:
   backport:
-    uses: upbound/uptest/.github/workflows/provider-backport.yml@main
+    uses: upbound/uptest/.github/workflows/provider-backport.yml@standard-runners

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,10 @@ on:
 
 jobs:
   ci:
-    uses: upbound/uptest/.github/workflows/provider-ci.yml@main
+    uses: upbound/uptest/.github/workflows/provider-ci.yml@standard-runners
     with:
       go-version: 1.21
+      cleanup-disk: true
     secrets:
       UPBOUND_MARKETPLACE_PUSH_ROBOT_USR: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR }}
       UPBOUND_MARKETPLACE_PUSH_ROBOT_PSW: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_PSW }}

--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -4,4 +4,4 @@ on: issue_comment
 
 jobs:
   comment-commands:
-    uses: upbound/uptest/.github/workflows/provider-commands.yml@main
+    uses: upbound/uptest/.github/workflows/provider-commands.yml@standard-runners

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,9 +6,10 @@ on:
 
 jobs:
   e2e:
-    uses: upbound/uptest/.github/workflows/pr-comment-trigger.yml@main
+    uses: upbound/uptest/.github/workflows/pr-comment-trigger.yml@standard-runners
     with:
       go-version: 1.21
+      cleanup-disk: true
     secrets:
       UPTEST_CLOUD_CREDENTIALS: ${{ secrets.UPTEST_CLOUD_CREDENTIALS }}
       UPTEST_DATASOURCE: ${{ secrets.UPTEST_DATASOURCE }}

--- a/.github/workflows/issue_triage.yml
+++ b/.github/workflows/issue_triage.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   community-issue-triage:
-    uses: upbound/uptest/.github/workflows/issue-triage.yml@main
+    uses: upbound/uptest/.github/workflows/issue-triage.yml@standard-runners
     secrets:
       UPBOUND_BOT_GITHUB_TOKEN: ${{ secrets.UPBOUND_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/native-provider-bump.yml
+++ b/.github/workflows/native-provider-bump.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   open-bump-pr:
-    uses: upbound/uptest/.github/workflows/native-provider-bump.yml@main
+    uses: upbound/uptest/.github/workflows/native-provider-bump.yml@standard-runners
     with:
       provider-source: hashicorp/google
       go-version: 1.21

--- a/.github/workflows/publish-service-artifacts.yml
+++ b/.github/workflows/publish-service-artifacts.yml
@@ -18,12 +18,13 @@ on:
 
 jobs:
   publish-service-artifacts:
-    uses: upbound/uptest/.github/workflows/provider-publish-service-artifacts.yml@main
+    uses: upbound/uptest/.github/workflows/provider-publish-service-artifacts.yml@standard-runners
     with:
       subpackages: ${{ github.event.inputs.subpackages }}
       size: ${{ github.event.inputs.size }}
       concurrency: ${{ github.event.inputs.concurrency }}
       go-version: 1.21
+      cleanup-disk: true
     secrets:
       UPBOUND_MARKETPLACE_PUSH_ROBOT_USR: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR_RC }}
       UPBOUND_MARKETPLACE_PUSH_ROBOT_PSW: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_PSW_RC }}

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -40,7 +40,7 @@ jobs:
           echo "We are going to scan the last ${supported_releases_number} releases for: ${images}"
 
   scan:
-    uses: upbound/uptest/.github/workflows/scan.yml@main
+    uses: upbound/uptest/.github/workflows/scan.yml@standard-runners
     needs:
       - setup-vars
     with:

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   tag:
-    uses: upbound/uptest/.github/workflows/provider-tag.yml@main
+    uses: upbound/uptest/.github/workflows/provider-tag.yml@standard-runners
     with:
       version: ${{ github.event.inputs.version }}
       message: ${{ github.event.inputs.message }}

--- a/.github/workflows/updoc.yml
+++ b/.github/workflows/updoc.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish-docs:
-    uses: upbound/uptest/.github/workflows/provider-updoc.yml@main
+    uses: upbound/uptest/.github/workflows/provider-updoc.yml@standard-runners
     with:
       providers: "monolith config"
       go-version: 1.21


### PR DESCRIPTION
<!--
Thank you for helping to improve Official GCP Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official GCP Provider pull request. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Official GCP Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Because the various self-hosted runners available for the `upbound` Github organization are not available for the `crossplane-contrib` organization, we are switching to the `standard-runners` branch of `upbound/uptest` to make the CI jobs run on standard hosted runners.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Will be tested in the CI pipelines.


[contribution process]: https://git.io/fj2m9
