### PR TITLE
Fix the wrong provider name reference from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ open an [issue](https://github.com/crossplane-contrib/provider-upjet-gcp/issues)
 
 ## Contact
 
-[#upbound-provider-aws](https://crossplane.slack.com/archives/C05E7EVM459) channel in
+[#upbound-provider-gcp](https://crossplane.slack.com/archives/C05E7EVM459) channel in
 [Crossplane Slack](https://slack.crossplane.io)
 
 ## Licensing


### PR DESCRIPTION
### Description of your changes

This PR fixes the wrong provider name reference from README.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

[contribution process]: https://git.io/fj2m9
