### PR TITLE
Generate license headers for setup.go files by consuming the upjet `1.1.5`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	dario.cat/mergo v1.0.0
 	github.com/crossplane/crossplane-runtime v1.15.1
 	github.com/crossplane/crossplane-tools v0.0.0-20230925130601-628280f8bf79
-	github.com/crossplane/upjet v1.1.4
+	github.com/crossplane/upjet v1.1.5
 	github.com/hashicorp/terraform-json v0.18.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.31.0
 	github.com/hashicorp/terraform-provider-google v1.20.1-0.20240304172718-a9e2f2c89f14

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ github.com/crossplane/crossplane-runtime v1.15.1 h1:g1h75tNYOQT152IUNxs8ZgSsRFQK
 github.com/crossplane/crossplane-runtime v1.15.1/go.mod h1:kRcJjJQmBFrR2n/KhwL8wYS7xNfq3D8eK4JliEScOHI=
 github.com/crossplane/crossplane-tools v0.0.0-20230925130601-628280f8bf79 h1:HigXs5tEQxWz0fcj8hzbU2UAZgEM7wPe0XRFOsrtF8Y=
 github.com/crossplane/crossplane-tools v0.0.0-20230925130601-628280f8bf79/go.mod h1:+e4OaFlOcmr0JvINHl/yvEYBrZawzTgj6pQumOH1SS0=
-github.com/crossplane/upjet v1.1.4 h1:IFavq26jciFXi+00c8hwFSOHoL558Mybd7AW+qOpzKs=
-github.com/crossplane/upjet v1.1.4/go.mod h1:0bHLtnejZ9bDeyXuBb9MSOQLvKo3+aoTeUBO8N0dGSA=
+github.com/crossplane/upjet v1.1.5 h1:Ad/fOoPqib9WlbgZ7/bkMfyvDFymodKiJBkDklQQyvE=
+github.com/crossplane/upjet v1.1.5/go.mod h1:0bHLtnejZ9bDeyXuBb9MSOQLvKo3+aoTeUBO8N0dGSA=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/dave/jennifer v1.4.1 h1:XyqG6cn5RQsTj3qlWQTKlRGAyrTcsk1kUmWdZBzRjDw=

--- a/internal/controller/zz_accesscontextmanager_setup.go
+++ b/internal/controller/zz_accesscontextmanager_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_activedirectory_setup.go
+++ b/internal/controller/zz_activedirectory_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_alloydb_setup.go
+++ b/internal/controller/zz_alloydb_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_apigee_setup.go
+++ b/internal/controller/zz_apigee_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_appengine_setup.go
+++ b/internal/controller/zz_appengine_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_artifact_setup.go
+++ b/internal/controller/zz_artifact_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_beyondcorp_setup.go
+++ b/internal/controller/zz_beyondcorp_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_bigquery_setup.go
+++ b/internal/controller/zz_bigquery_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_bigtable_setup.go
+++ b/internal/controller/zz_bigtable_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_binaryauthorization_setup.go
+++ b/internal/controller/zz_binaryauthorization_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_certificatemanager_setup.go
+++ b/internal/controller/zz_certificatemanager_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_cloud_setup.go
+++ b/internal/controller/zz_cloud_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_cloudbuild_setup.go
+++ b/internal/controller/zz_cloudbuild_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_cloudfunctions2_setup.go
+++ b/internal/controller/zz_cloudfunctions2_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_cloudfunctions_setup.go
+++ b/internal/controller/zz_cloudfunctions_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_cloudplatform_setup.go
+++ b/internal/controller/zz_cloudplatform_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_cloudrun_setup.go
+++ b/internal/controller/zz_cloudrun_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_cloudscheduler_setup.go
+++ b/internal/controller/zz_cloudscheduler_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_cloudtasks_setup.go
+++ b/internal/controller/zz_cloudtasks_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_composer_setup.go
+++ b/internal/controller/zz_composer_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_compute_setup.go
+++ b/internal/controller/zz_compute_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_config_setup.go
+++ b/internal/controller/zz_config_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_container_setup.go
+++ b/internal/controller/zz_container_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_containeranalysis_setup.go
+++ b/internal/controller/zz_containeranalysis_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_containeraws_setup.go
+++ b/internal/controller/zz_containeraws_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_containerazure_setup.go
+++ b/internal/controller/zz_containerazure_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_datacatalog_setup.go
+++ b/internal/controller/zz_datacatalog_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_dataflow_setup.go
+++ b/internal/controller/zz_dataflow_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_datafusion_setup.go
+++ b/internal/controller/zz_datafusion_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_datalossprevention_setup.go
+++ b/internal/controller/zz_datalossprevention_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_dataplex_setup.go
+++ b/internal/controller/zz_dataplex_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_dataproc_setup.go
+++ b/internal/controller/zz_dataproc_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_datastore_setup.go
+++ b/internal/controller/zz_datastore_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_datastream_setup.go
+++ b/internal/controller/zz_datastream_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_dialogflowcx_setup.go
+++ b/internal/controller/zz_dialogflowcx_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_dns_setup.go
+++ b/internal/controller/zz_dns_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_documentai_setup.go
+++ b/internal/controller/zz_documentai_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_essentialcontacts_setup.go
+++ b/internal/controller/zz_essentialcontacts_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_eventarc_setup.go
+++ b/internal/controller/zz_eventarc_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_filestore_setup.go
+++ b/internal/controller/zz_filestore_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_firebaserules_setup.go
+++ b/internal/controller/zz_firebaserules_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_gke_setup.go
+++ b/internal/controller/zz_gke_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_gkehub_setup.go
+++ b/internal/controller/zz_gkehub_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_healthcare_setup.go
+++ b/internal/controller/zz_healthcare_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_iam_setup.go
+++ b/internal/controller/zz_iam_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_iap_setup.go
+++ b/internal/controller/zz_iap_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_identityplatform_setup.go
+++ b/internal/controller/zz_identityplatform_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_kms_setup.go
+++ b/internal/controller/zz_kms_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_logging_setup.go
+++ b/internal/controller/zz_logging_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_memcache_setup.go
+++ b/internal/controller/zz_memcache_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_mlengine_setup.go
+++ b/internal/controller/zz_mlengine_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_monitoring_setup.go
+++ b/internal/controller/zz_monitoring_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_monolith_setup.go
+++ b/internal/controller/zz_monolith_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_networkconnectivity_setup.go
+++ b/internal/controller/zz_networkconnectivity_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_networkmanagement_setup.go
+++ b/internal/controller/zz_networkmanagement_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_notebooks_setup.go
+++ b/internal/controller/zz_notebooks_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_osconfig_setup.go
+++ b/internal/controller/zz_osconfig_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_oslogin_setup.go
+++ b/internal/controller/zz_oslogin_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_privateca_setup.go
+++ b/internal/controller/zz_privateca_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_pubsub_setup.go
+++ b/internal/controller/zz_pubsub_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_redis_setup.go
+++ b/internal/controller/zz_redis_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_secretmanager_setup.go
+++ b/internal/controller/zz_secretmanager_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_servicenetworking_setup.go
+++ b/internal/controller/zz_servicenetworking_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_sourcerepo_setup.go
+++ b/internal/controller/zz_sourcerepo_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_spanner_setup.go
+++ b/internal/controller/zz_spanner_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_sql_setup.go
+++ b/internal/controller/zz_sql_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_storage_setup.go
+++ b/internal/controller/zz_storage_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_storagetransfer_setup.go
+++ b/internal/controller/zz_storagetransfer_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_tpu_setup.go
+++ b/internal/controller/zz_tpu_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_vertexai_setup.go
+++ b/internal/controller/zz_vertexai_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_vpcaccess_setup.go
+++ b/internal/controller/zz_vpcaccess_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_workflows_setup.go
+++ b/internal/controller/zz_workflows_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (


### PR DESCRIPTION
### Description of your changes

This PR generates license headers for setup.go files by consuming the upjet `1.1.5`. More details please see https://github.com/crossplane/upjet/pull/376.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Uptest Run: https://github.com/crossplane-contrib/provider-upjet-gcp/actions/runs/8293779286

[contribution process]: https://git.io/fj2m9
