### PR TITLE
Add SSA merge strategy to container Cluster's nodeConfig to avoid fights over ownership.

### DIFF
--- a/apis/container/v1beta1/zz_cluster_types.go
+++ b/apis/container/v1beta1/zz_cluster_types.go
@@ -910,6 +910,8 @@ type ClusterInitParameters struct {
 	NetworkingMode *string `json:"networkingMode,omitempty" tf:"networking_mode,omitempty"`
 
 	// Parameters used in creating the default node pool. Structure is documented below.
+	// +listType=map
+	// +listMapKey=index
 	NodeConfig []NodeConfigInitParameters `json:"nodeConfig,omitempty" tf:"node_config,omitempty"`
 
 	// The list of zones in which the cluster's nodes
@@ -1212,6 +1214,8 @@ type ClusterObservation struct {
 	NetworkingMode *string `json:"networkingMode,omitempty" tf:"networking_mode,omitempty"`
 
 	// Parameters used in creating the default node pool. Structure is documented below.
+	// +listType=map
+	// +listMapKey=index
 	NodeConfig []NodeConfigObservation `json:"nodeConfig,omitempty" tf:"node_config,omitempty"`
 
 	// The list of zones in which the cluster's nodes
@@ -1566,6 +1570,8 @@ type ClusterParameters struct {
 
 	// Parameters used in creating the default node pool. Structure is documented below.
 	// +kubebuilder:validation:Optional
+	// +listType=map
+	// +listMapKey=index
 	NodeConfig []NodeConfigParameters `json:"nodeConfig,omitempty" tf:"node_config,omitempty"`
 
 	// The list of zones in which the cluster's nodes
@@ -3290,6 +3296,10 @@ type NodeConfigInitParameters struct {
 	// will delete and recreate all nodes in the node pool.
 	ImageType *string `json:"imageType,omitempty" tf:"image_type,omitempty"`
 
+	// This is an injected field with a default value for being able to merge items of the parent object list.
+	// +kubebuilder:default:="0"
+	Index *string `json:"index,omitempty" tf:"-"`
+
 	// Kubelet configuration, currently supported attributes can be found here.
 	// Structure is documented below.
 	KubeletConfig []KubeletConfigInitParameters `json:"kubeletConfig,omitempty" tf:"kubelet_config,omitempty"`
@@ -3518,6 +3528,10 @@ type NodeConfigObservation struct {
 	// will delete and recreate all nodes in the node pool.
 	ImageType *string `json:"imageType,omitempty" tf:"image_type,omitempty"`
 
+	// This is an injected field with a default value for being able to merge items of the parent object list.
+	// +kubebuilder:default:="0"
+	Index *string `json:"index,omitempty" tf:"-"`
+
 	// Kubelet configuration, currently supported attributes can be found here.
 	// Structure is documented below.
 	KubeletConfig []KubeletConfigObservation `json:"kubeletConfig,omitempty" tf:"kubelet_config,omitempty"`
@@ -3685,6 +3699,11 @@ type NodeConfigParameters struct {
 	// will delete and recreate all nodes in the node pool.
 	// +kubebuilder:validation:Optional
 	ImageType *string `json:"imageType,omitempty" tf:"image_type,omitempty"`
+
+	// This is an injected field with a default value for being able to merge items of the parent object list.
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default:="0"
+	Index *string `json:"index" tf:"-"`
 
 	// Kubelet configuration, currently supported attributes can be found here.
 	// Structure is documented below.

--- a/apis/container/v1beta1/zz_generated.deepcopy.go
+++ b/apis/container/v1beta1/zz_generated.deepcopy.go
@@ -7463,6 +7463,11 @@ func (in *NodeConfigInitParameters) DeepCopyInto(out *NodeConfigInitParameters) 
 		*out = new(string)
 		**out = **in
 	}
+	if in.Index != nil {
+		in, out := &in.Index, &out.Index
+		*out = new(string)
+		**out = **in
+	}
 	if in.KubeletConfig != nil {
 		in, out := &in.KubeletConfig, &out.KubeletConfig
 		*out = make([]KubeletConfigInitParameters, len(*in))
@@ -7939,6 +7944,11 @@ func (in *NodeConfigObservation) DeepCopyInto(out *NodeConfigObservation) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Index != nil {
+		in, out := &in.Index, &out.Index
+		*out = new(string)
+		**out = **in
+	}
 	if in.KubeletConfig != nil {
 		in, out := &in.KubeletConfig, &out.KubeletConfig
 		*out = make([]KubeletConfigObservation, len(*in))
@@ -8214,6 +8224,11 @@ func (in *NodeConfigParameters) DeepCopyInto(out *NodeConfigParameters) {
 	}
 	if in.ImageType != nil {
 		in, out := &in.ImageType, &out.ImageType
+		*out = new(string)
+		**out = **in
+	}
+	if in.Index != nil {
+		in, out := &in.Index, &out.Index
 		*out = new(string)
 		**out = **in
 	}

--- a/config/container/config.go
+++ b/config/container/config.go
@@ -121,6 +121,17 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 			Type:      "github.com/upbound/provider-gcp/apis/compute/v1beta1.Subnetwork",
 			Extractor: common.PathSelfLinkExtractor,
 		}
+		r.ServerSideApplyMergeStrategies["node_config"] = config.MergeStrategy{
+			ListMergeStrategy: config.ListMergeStrategy{
+				MergeStrategy: config.ListTypeMap,
+				ListMapKeys: config.ListMapKeys{
+					InjectedKey: config.InjectedKey{
+						Key:          "index",
+						DefaultValue: `"0"`,
+					},
+				},
+			},
+		}
 		config.MarkAsRequired(r.TerraformResource, "location")
 	})
 

--- a/package/crds/container.gcp.upbound.io_clusters.yaml
+++ b/package/crds/container.gcp.upbound.io_clusters.yaml
@@ -1207,6 +1207,11 @@ spec:
                             The image type to use for this node. Note that changing the image type
                             will delete and recreate all nodes in the node pool.
                           type: string
+                        index:
+                          default: "0"
+                          description: This is an injected field with a default value
+                            for being able to merge items of the parent object list.
+                          type: string
                         kubeletConfig:
                           description: |-
                             Kubelet configuration, currently supported attributes can be found here.
@@ -1544,6 +1549,9 @@ spec:
                           type: array
                       type: object
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - index
+                    x-kubernetes-list-type: map
                   nodeLocations:
                     description: |-
                       The list of zones in which the cluster's nodes
@@ -3042,6 +3050,11 @@ spec:
                             The image type to use for this node. Note that changing the image type
                             will delete and recreate all nodes in the node pool.
                           type: string
+                        index:
+                          default: "0"
+                          description: This is an injected field with a default value
+                            for being able to merge items of the parent object list.
+                          type: string
                         kubeletConfig:
                           description: |-
                             Kubelet configuration, currently supported attributes can be found here.
@@ -3379,6 +3392,9 @@ spec:
                           type: array
                       type: object
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - index
+                    x-kubernetes-list-type: map
                   nodeLocations:
                     description: |-
                       The list of zones in which the cluster's nodes
@@ -5046,6 +5062,11 @@ spec:
                             The image type to use for this node. Note that changing the image type
                             will delete and recreate all nodes in the node pool.
                           type: string
+                        index:
+                          default: "0"
+                          description: This is an injected field with a default value
+                            for being able to merge items of the parent object list.
+                          type: string
                         kubeletConfig:
                           description: |-
                             Kubelet configuration, currently supported attributes can be found here.
@@ -5307,6 +5328,9 @@ spec:
                           type: array
                       type: object
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - index
+                    x-kubernetes-list-type: map
                   nodeLocations:
                     description: |-
                       The list of zones in which the cluster's nodes


### PR DESCRIPTION


<!--
Thank you for helping to improve Official GCP Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official GCP Provider pull request. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

The Cluster nodeConfig is a singleton list containing the node config for the pool. By default lists are treated as atomic by server-side-apply, which means only one manager can own them. nodeConfig contains fields resolved by the provider (service account) so if you also try to patch some of the other fields with a composition function then the provider and composition repeatedly delete each others fields.

The ListTypeMap strategy treats the list elements similarly to a granular map, which is what we need, but it requires a key by which to identify each element of the list. There is no such key for nodeConfig, but since it's a singleton we can inject a default using a non-existent name with a fixed value.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Running in kind against GKE
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
