### PR TITLE
Switch to the new API for `marking as required` the fields for some resources

### DIFF
--- a/config/cloudcomposer/config.go
+++ b/config/cloudcomposer/config.go
@@ -27,6 +27,6 @@ func Configure(p *config.Provider) {
 		r.References["private_environment_config.cloud_composer_connection_subnetwork"] = config.Reference{
 			Type: "github.com/upbound/provider-gcp/apis/compute/v1beta1.Subnetwork",
 		}
-		config.MarkAsRequired(r.TerraformResource, "region")
+		r.MarkAsRequired("region")
 	})
 }

--- a/config/cloudscheduler/config.go
+++ b/config/cloudscheduler/config.go
@@ -16,6 +16,6 @@ func Configure(p *config.Provider) {
 			// Note(donovanmuller): What about support for 'pubsub/v1beta1.LiteTopic' reference?
 			Type: "github.com/upbound/provider-gcp/apis/pubsub/v1beta1.Topic",
 		}
-		config.MarkAsRequired(r.TerraformResource, "region")
+		r.MarkAsRequired("region")
 	})
 }

--- a/config/compute/config.go
+++ b/config/compute/config.go
@@ -33,7 +33,7 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 	//  all resources separately and no complex logic here.
 
 	p.AddResourceConfigurator("google_compute_autoscaler", func(r *config.Resource) {
-		config.MarkAsRequired(r.TerraformResource, "zone")
+		r.MarkAsRequired("zone")
 	})
 
 	p.AddResourceConfigurator("google_compute_backend_service", func(r *config.Resource) {
@@ -168,7 +168,7 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 		r.References["boot_disk.initialize_params.image"] = config.Reference{
 			Type: "Image",
 		}
-		config.MarkAsRequired(r.TerraformResource, "zone")
+		r.MarkAsRequired("zone")
 	})
 
 	p.AddResourceConfigurator("google_compute_instance_iam_member", func(r *config.Resource) {
@@ -210,7 +210,7 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 			Type:      "Network",
 			Extractor: common.PathSelfLinkExtractor,
 		}
-		config.MarkAsRequired(r.TerraformResource, "zone")
+		r.MarkAsRequired("zone")
 	})
 
 	p.AddResourceConfigurator("google_compute_global_address", func(r *config.Resource) {
@@ -248,7 +248,7 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 			Type:      "TargetPool",
 			Extractor: common.PathSelfLinkExtractor,
 		}
-		config.MarkAsRequired(r.TerraformResource, "zone")
+		r.MarkAsRequired("zone")
 	})
 
 	p.AddResourceConfigurator("google_compute_interconnect_attachment", func(r *config.Resource) {
@@ -268,11 +268,11 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 			Type:      "Subnetwork",
 			Extractor: common.ExtractResourceIDFuncPath,
 		}
-		config.MarkAsRequired(r.TerraformResource, "zone")
+		r.MarkAsRequired("zone")
 	})
 
 	p.AddResourceConfigurator("google_compute_resource_policy", func(r *config.Resource) {
-		config.MarkAsRequired(r.TerraformResource, "region")
+		r.MarkAsRequired("region")
 	})
 
 	p.AddResourceConfigurator("google_compute_target_pool", func(r *config.Resource) {
@@ -281,7 +281,7 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 		r.References["health_checks"] = config.Reference{
 			Type: "HTTPHealthCheck",
 		}
-		config.MarkAsRequired(r.TerraformResource, "region")
+		r.MarkAsRequired("region")
 	})
 
 	p.AddResourceConfigurator("google_compute_network_endpoint", func(r *config.Resource) {
@@ -351,7 +351,7 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 			Type:      "TargetPool",
 			Extractor: common.PathSelfLinkExtractor,
 		}
-		config.MarkAsRequired(r.TerraformResource, "region")
+		r.MarkAsRequired("region")
 	})
 
 	p.AddResourceConfigurator("google_compute_region_target_http_proxy", func(r *config.Resource) {
@@ -378,7 +378,7 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 		config.MarkAsRequired(r.TerraformResource, "region")
 	})
 	p.AddResourceConfigurator("google_compute_region_autoscaler", func(r *config.Resource) {
-		config.MarkAsRequired(r.TerraformResource, "region")
+		r.MarkAsRequired("region")
 	})
 
 	p.AddResourceConfigurator("google_compute_region_disk", func(r *config.Resource) {
@@ -396,10 +396,6 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 	})
 
 	p.AddResourceConfigurator("google_compute_region_health_check", func(r *config.Resource) {
-		config.MarkAsRequired(r.TerraformResource, "region")
-	})
-
-	p.AddResourceConfigurator("google_compute_region_per_instance_config", func(r *config.Resource) {
 		config.MarkAsRequired(r.TerraformResource, "region")
 	})
 
@@ -473,7 +469,7 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 		r.References["nat_subnets"] = config.Reference{
 			Type: "Subnetwork",
 		}
-		config.MarkAsRequired(r.TerraformResource, "region")
+		r.MarkAsRequired("region")
 	})
 
 	p.AddResourceConfigurator("google_compute_route", func(r *config.Resource) {

--- a/config/datacatalog/config.go
+++ b/config/datacatalog/config.go
@@ -12,6 +12,6 @@ import (
 // ResourceConfigurators.
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("google_data_catalog_entry_group", func(r *config.Resource) {
-		config.MarkAsRequired(r.TerraformResource, "region")
+		r.MarkAsRequired("region")
 	})
 }

--- a/config/externalname.go
+++ b/config/externalname.go
@@ -185,7 +185,7 @@ var terraformPluginSDKExternalNameConfigs = map[string]config.ExternalName{
 	// Imported by using the following format: projects/{{project}}/regions/{{region}}/targetPools/{{name}}
 	"google_compute_target_pool": config.TemplatedStringAsIdentifier("name", "projects/{{ .setup.configuration.project }}/regions/{{ .parameters.region }}/targetPools/{{ .external_name }}"),
 	// Imported by using the following format: projects/{{project}}/zones/{{zone}}/instanceGroupManagers/{{name}}
-	"google_compute_instance_group_manager": config.TemplatedStringAsIdentifier("name", "projects/{{ .setup.configuration.project }}/zones/{{ .parameters.zone }}/targetPools/{{ .external_name }}"),
+	"google_compute_instance_group_manager": config.TemplatedStringAsIdentifier("name", "projects/{{ if .parameters.project }}{{ .parameters.project }}{{ else }}{{ .setup.configuration.project }}{{ end }}/zones/{{ .parameters.zone }}/instanceGroupManagers/{{ .external_name }}"),
 	// Imported by using the following format: projects/{{project}}/zones/{{zone}}/instances/{{instance}} roles/compute.osLogin user:jane@example.com
 	"google_compute_instance_iam_member": config.IdentifierFromProvider,
 	// Imported by using the following format: projects/{{project}}/regions/{{region}}/interconnectAttachments/{{name}}

--- a/examples/composer/environment.yaml
+++ b/examples/composer/environment.yaml
@@ -13,9 +13,3 @@ metadata:
 spec:
   forProvider:
     region: us-east1
-    config:
-      - nodeConfig:
-        - ipAllocationPolicy:
-            - useIpAliases: true
-              clusterIpv4CidrBlock: 10.80.0.0/14
-              servicesIpv4CidrBlock: 10.84.0.0/20

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	dario.cat/mergo v1.0.0
 	github.com/crossplane/crossplane-runtime v1.15.1
 	github.com/crossplane/crossplane-tools v0.0.0-20230925130601-628280f8bf79
-	github.com/crossplane/upjet v1.1.5
+	github.com/crossplane/upjet v1.1.6
 	github.com/hashicorp/terraform-json v0.18.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.31.0
 	github.com/hashicorp/terraform-provider-google v1.20.1-0.20240304172718-a9e2f2c89f14
@@ -21,8 +21,6 @@ require (
 	sigs.k8s.io/controller-runtime v0.17.2
 	sigs.k8s.io/controller-tools v0.14.0
 )
-
-replace github.com/crossplane/upjet => github.com/sergenyalcin/upjet v0.0.0-20240319122659-36a16b298cba
 
 require (
 	bitbucket.org/creachadair/stringset v0.0.8 // indirect

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,8 @@ require (
 	sigs.k8s.io/controller-tools v0.14.0
 )
 
+replace github.com/crossplane/upjet => github.com/sergenyalcin/upjet v0.0.0-20240319122659-36a16b298cba
+
 require (
 	bitbucket.org/creachadair/stringset v0.0.8 // indirect
 	cloud.google.com/go v0.112.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,6 @@ github.com/crossplane/crossplane-runtime v1.15.1 h1:g1h75tNYOQT152IUNxs8ZgSsRFQK
 github.com/crossplane/crossplane-runtime v1.15.1/go.mod h1:kRcJjJQmBFrR2n/KhwL8wYS7xNfq3D8eK4JliEScOHI=
 github.com/crossplane/crossplane-tools v0.0.0-20230925130601-628280f8bf79 h1:HigXs5tEQxWz0fcj8hzbU2UAZgEM7wPe0XRFOsrtF8Y=
 github.com/crossplane/crossplane-tools v0.0.0-20230925130601-628280f8bf79/go.mod h1:+e4OaFlOcmr0JvINHl/yvEYBrZawzTgj6pQumOH1SS0=
-github.com/crossplane/upjet v1.1.5 h1:Ad/fOoPqib9WlbgZ7/bkMfyvDFymodKiJBkDklQQyvE=
-github.com/crossplane/upjet v1.1.5/go.mod h1:0bHLtnejZ9bDeyXuBb9MSOQLvKo3+aoTeUBO8N0dGSA=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/dave/jennifer v1.4.1 h1:XyqG6cn5RQsTj3qlWQTKlRGAyrTcsk1kUmWdZBzRjDw=
@@ -355,6 +353,8 @@ github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3c
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/sergenyalcin/upjet v0.0.0-20240319122659-36a16b298cba h1:NOdYhmnKTcCfnV7leYZTS2ngKtz1VgFn/GQWba+N37I=
+github.com/sergenyalcin/upjet v0.0.0-20240319122659-36a16b298cba/go.mod h1:0bHLtnejZ9bDeyXuBb9MSOQLvKo3+aoTeUBO8N0dGSA=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/crossplane/crossplane-runtime v1.15.1 h1:g1h75tNYOQT152IUNxs8ZgSsRFQK
 github.com/crossplane/crossplane-runtime v1.15.1/go.mod h1:kRcJjJQmBFrR2n/KhwL8wYS7xNfq3D8eK4JliEScOHI=
 github.com/crossplane/crossplane-tools v0.0.0-20230925130601-628280f8bf79 h1:HigXs5tEQxWz0fcj8hzbU2UAZgEM7wPe0XRFOsrtF8Y=
 github.com/crossplane/crossplane-tools v0.0.0-20230925130601-628280f8bf79/go.mod h1:+e4OaFlOcmr0JvINHl/yvEYBrZawzTgj6pQumOH1SS0=
+github.com/crossplane/upjet v1.1.6 h1:0Sx6P+Y3OJK6AnXl7W83F3GXxORnC2fnOzEfxK1OCqs=
+github.com/crossplane/upjet v1.1.6/go.mod h1:0bHLtnejZ9bDeyXuBb9MSOQLvKo3+aoTeUBO8N0dGSA=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/dave/jennifer v1.4.1 h1:XyqG6cn5RQsTj3qlWQTKlRGAyrTcsk1kUmWdZBzRjDw=
@@ -353,8 +355,6 @@ github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3c
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/sergenyalcin/upjet v0.0.0-20240319122659-36a16b298cba h1:NOdYhmnKTcCfnV7leYZTS2ngKtz1VgFn/GQWba+N37I=
-github.com/sergenyalcin/upjet v0.0.0-20240319122659-36a16b298cba/go.mod h1:0bHLtnejZ9bDeyXuBb9MSOQLvKo3+aoTeUBO8N0dGSA=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=


### PR DESCRIPTION
### Description of your changes

This PR switches to the [new API for `marking as required`](https://github.com/sergenyalcin/upjet/blob/845dbf6b1b11cdcc329cea004fc29e2d23c5343b/pkg/config/common.go#L129) the fields. The new API will mark as required the fields during the generation without any native resource schema change. For mor details of this new API please see this [PR](https://github.com/crossplane/upjet/pull/381). The base strategies we decided in this PR:
- Upjet's `config.MarkAsRequired` still modifies the native schema (no change in its implementation) but it's now deprecated in favor of `config.Resource.MarkAsRequired`.
- Other clients of the config.MarkAsRequired are not updated to use the new config.Resource.MarkAsRequired in this PR because the config.MarkAsRequired modifies Terraform's runtime behavior (potentially also outside the context of the defaulting CustomizeDiff functions) by manipulating the native schema, and so we would like to test those resources which are updated to use the new config.Resource.MarkAsRequired. So it's a larger effort to transition all the clients of the config.MarkAsRequired and we limit the scope of this PR by only updating the configurations of the following resources.

Fixes #472 

The root cause of #472 is native schema change of the `zone` and `region` field. The new `CustomizeDiff` functions of the underlying provider, [DefaultProviderRegion](https://github.com/hashicorp/terraform-provider-google/blob/a9e2f2c89f14496301cac609f3e8c71fc9558a2a/google/tpgresource/utils.go#L791) and [DefaultProviderZone](https://github.com/hashicorp/terraform-provider-google/blob/a9e2f2c89f14496301cac609f3e8c71fc9558a2a/google/tpgresource/utils.go#L809), checks the `Computed` fields of the resource schemas and gives some decisions according to the values. At this point, because of manipulating the resource schema (what we must not do), we observe this issue. By this change, we will revert the schema changes for the affected resources. The affected resources were determined according to the two following rules:

- The resource configuration should contain schema manipulation via `MarkAsRequired` for `zone` or `region` fields.
- The native schema of resource should contain at least on of the mentioned `CustomizeDiff` functions.

Switched to the new API for the following resources:

1. `Environment.composer`
2. `Job.cloudscheduler`
3. `Autoscaler.compute`
4. `Instance.compute`
5. `InstanceGroup.compute`
6. `InstanceGroupManager.compute`
7. `NetworkEndpointGroup.compute`
8. `ResourcePolicy.compute`
9. `TargetPool.compute`
10. `RegionInstanceGroupManager.compute`
11. `RegionAutoScaler.compute`
12. `ServiceAttachment.compute`
13. `EntryGroup.datacatalog`

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

1. `Instance.compute`: https://github.com/crossplane-contrib/provider-upjet-gcp/actions/runs/8343310426
2. `Job.cloudscheduler`: https://github.com/crossplane-contrib/provider-upjet-gcp/actions/runs/8343708323
3. `InstanceGroup.compute`: https://github.com/crossplane-contrib/provider-upjet-gcp/actions/runs/8343704491
4. `ResourcePolicy.compute`: https://github.com/crossplane-contrib/provider-upjet-gcp/actions/runs/8343851010
5. `EntryGroup.datacatalog`: https://github.com/crossplane-contrib/provider-upjet-gcp/actions/runs/8343873861
6. `RegionAutoScaler.compute`: https://github.com/crossplane-contrib/provider-upjet-gcp/actions/runs/8344124389
7. `NetworkEndpointGroup.compute`: https://github.com/crossplane-contrib/provider-upjet-gcp/actions/runs/8344103249
8. `RegionInstanceGroupManager.compute`: https://github.com/crossplane-contrib/provider-upjet-gcp/actions/runs/8344548614
9. `ServiceAttachment.compute`: Manually (because of manual intervention need)
10. `TargetPool.compute`: https://github.com/crossplane-contrib/provider-upjet-gcp/actions/runs/8344649274
11. `Autoscaler.compute`: https://github.com/crossplane-contrib/provider-upjet-gcp/actions/runs/8345034404
12. `InstanceGroupManager.compute`: https://github.com/crossplane-contrib/provider-upjet-gcp/actions/runs/8345034404
13. `Environment.composer`: Manually (because of service account permission issues)

[contribution process]: https://git.io/fj2m9
