### PR TITLE
[User.Sql] publish password to Connection Secret

### DIFF
--- a/config/sql/config.go
+++ b/config/sql/config.go
@@ -117,6 +117,14 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 		r.References["instance"] = config.Reference{
 			Type: "DatabaseInstance",
 		}
+
+		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]any) (map[string][]byte, error) {
+			conn := map[string][]byte{}
+			if a, ok := attr["password"].(string); ok {
+				conn["password"] = []byte(a)
+			}
+			return conn, nil
+		}
 	})
 	p.AddResourceConfigurator("google_sql_ssl_cert", func(r *config.Resource) {
 		r.References["instance"] = config.Reference{

--- a/examples/sql/user.yaml
+++ b/examples/sql/user.yaml
@@ -19,6 +19,9 @@ spec:
     instanceSelector:
       matchLabels:
         testing.upbound.io/example-name: example_instance
+  writeConnectionSecretToRef:
+    name: example-sql-db-user-secret
+    namespace: upbound-system
 
 ---
 


### PR DESCRIPTION

### Description of your changes

To effectively use this MR within higher level abstractions like https://github.com/upbound/configuration-gcp-database and eventually https://github.com/upbound/platform-ref-gcp/ we need a reliable way to expose SQL User password through the connection secret

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

```
diff --git a/examples/sql/user.yaml b/examples/sql/user.yaml
index dbe3e7f9..987fb3a7 100644
--- a/examples/sql/user.yaml
+++ b/examples/sql/user.yaml
@@ -48,7 +48,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example_instance
   # ${Rand...} is not valid YAML and is used with automated testing
-  name: example-instance-${Rand.RFC1123Subdomain}
+  name: example-instance-yury-test
 spec:
   forProvider:
     region: "us-central1"


k apply -f examples/sql/user.yaml
...
 k get -f examples/sql/user.yaml
NAME                                   READY   SYNCED   EXTERNAL-NAME   AGE
user.sql.gcp.upbound.io/example-user   True    True     example-user    16m

NAME                      TYPE     DATA   AGE
secret/example-sql-user   Opaque   1      16m

NAME                                                             READY   SYNCED   EXTERNAL-NAME                AGE
databaseinstance.sql.gcp.upbound.io/example-instance-yury-test   True    True     example-instance-yury-test   16m

k view-secret -n upbound-system example-sql-db-user-secret
Multiple sub keys found. Specify another argument, one of:
-> attribute.password
-> password

 k view-secret -n upbound-system example-sql-db-user-secret password
changeme%
```

Plus uptest below

[contribution process]: https://git.io/fj2m9
