### PR TITLE
Change the `Reference.Type` API with `Reference.TerraformName`

### DIFF
--- a/apis/accesscontextmanager/v1beta1/zz_serviceperimeter_types.go
+++ b/apis/accesscontextmanager/v1beta1/zz_serviceperimeter_types.go
@@ -1353,15 +1353,15 @@ type SpecInitParameters struct {
 	// origins within the perimeter. For Service Perimeter Bridge, must
 	// be empty.
 	// Format: accessPolicies/{policy_id}/accessLevels/{access_level_name}
-	// +crossplane:generate:reference:type=AccessLevel
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/accesscontextmanager/v1beta1.AccessLevel
 	// +listType=set
 	AccessLevels []*string `json:"accessLevels,omitempty" tf:"access_levels,omitempty"`
 
-	// References to AccessLevel to populate accessLevels.
+	// References to AccessLevel in accesscontextmanager to populate accessLevels.
 	// +kubebuilder:validation:Optional
 	AccessLevelsRefs []v1.Reference `json:"accessLevelsRefs,omitempty" tf:"-"`
 
-	// Selector for a list of AccessLevel to populate accessLevels.
+	// Selector for a list of AccessLevel in accesscontextmanager to populate accessLevels.
 	// +kubebuilder:validation:Optional
 	AccessLevelsSelector *v1.Selector `json:"accessLevelsSelector,omitempty" tf:"-"`
 
@@ -1458,16 +1458,16 @@ type SpecParameters struct {
 	// origins within the perimeter. For Service Perimeter Bridge, must
 	// be empty.
 	// Format: accessPolicies/{policy_id}/accessLevels/{access_level_name}
-	// +crossplane:generate:reference:type=AccessLevel
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/accesscontextmanager/v1beta1.AccessLevel
 	// +kubebuilder:validation:Optional
 	// +listType=set
 	AccessLevels []*string `json:"accessLevels,omitempty" tf:"access_levels,omitempty"`
 
-	// References to AccessLevel to populate accessLevels.
+	// References to AccessLevel in accesscontextmanager to populate accessLevels.
 	// +kubebuilder:validation:Optional
 	AccessLevelsRefs []v1.Reference `json:"accessLevelsRefs,omitempty" tf:"-"`
 
-	// Selector for a list of AccessLevel to populate accessLevels.
+	// Selector for a list of AccessLevel in accesscontextmanager to populate accessLevels.
 	// +kubebuilder:validation:Optional
 	AccessLevelsSelector *v1.Selector `json:"accessLevelsSelector,omitempty" tf:"-"`
 
@@ -1600,15 +1600,15 @@ type StatusInitParameters struct {
 	// origins within the perimeter. For Service Perimeter Bridge, must
 	// be empty.
 	// Format: accessPolicies/{policy_id}/accessLevels/{access_level_name}
-	// +crossplane:generate:reference:type=AccessLevel
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/accesscontextmanager/v1beta1.AccessLevel
 	// +listType=set
 	AccessLevels []*string `json:"accessLevels,omitempty" tf:"access_levels,omitempty"`
 
-	// References to AccessLevel to populate accessLevels.
+	// References to AccessLevel in accesscontextmanager to populate accessLevels.
 	// +kubebuilder:validation:Optional
 	AccessLevelsRefs []v1.Reference `json:"accessLevelsRefs,omitempty" tf:"-"`
 
-	// Selector for a list of AccessLevel to populate accessLevels.
+	// Selector for a list of AccessLevel in accesscontextmanager to populate accessLevels.
 	// +kubebuilder:validation:Optional
 	AccessLevelsSelector *v1.Selector `json:"accessLevelsSelector,omitempty" tf:"-"`
 
@@ -1705,16 +1705,16 @@ type StatusParameters struct {
 	// origins within the perimeter. For Service Perimeter Bridge, must
 	// be empty.
 	// Format: accessPolicies/{policy_id}/accessLevels/{access_level_name}
-	// +crossplane:generate:reference:type=AccessLevel
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/accesscontextmanager/v1beta1.AccessLevel
 	// +kubebuilder:validation:Optional
 	// +listType=set
 	AccessLevels []*string `json:"accessLevels,omitempty" tf:"access_levels,omitempty"`
 
-	// References to AccessLevel to populate accessLevels.
+	// References to AccessLevel in accesscontextmanager to populate accessLevels.
 	// +kubebuilder:validation:Optional
 	AccessLevelsRefs []v1.Reference `json:"accessLevelsRefs,omitempty" tf:"-"`
 
-	// Selector for a list of AccessLevel to populate accessLevels.
+	// Selector for a list of AccessLevel in accesscontextmanager to populate accessLevels.
 	// +kubebuilder:validation:Optional
 	AccessLevelsSelector *v1.Selector `json:"accessLevelsSelector,omitempty" tf:"-"`
 

--- a/apis/cloudfunctions/v1beta1/zz_functioniammember_types.go
+++ b/apis/cloudfunctions/v1beta1/zz_functioniammember_types.go
@@ -43,14 +43,14 @@ type ConditionParameters struct {
 
 type FunctionIAMMemberInitParameters struct {
 
-	// +crossplane:generate:reference:type=Function
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/cloudfunctions/v1beta1.Function
 	CloudFunction *string `json:"cloudFunction,omitempty" tf:"cloud_function,omitempty"`
 
-	// Reference to a Function to populate cloudFunction.
+	// Reference to a Function in cloudfunctions to populate cloudFunction.
 	// +kubebuilder:validation:Optional
 	CloudFunctionRef *v1.Reference `json:"cloudFunctionRef,omitempty" tf:"-"`
 
-	// Selector for a Function to populate cloudFunction.
+	// Selector for a Function in cloudfunctions to populate cloudFunction.
 	// +kubebuilder:validation:Optional
 	CloudFunctionSelector *v1.Selector `json:"cloudFunctionSelector,omitempty" tf:"-"`
 
@@ -85,15 +85,15 @@ type FunctionIAMMemberObservation struct {
 
 type FunctionIAMMemberParameters struct {
 
-	// +crossplane:generate:reference:type=Function
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/cloudfunctions/v1beta1.Function
 	// +kubebuilder:validation:Optional
 	CloudFunction *string `json:"cloudFunction,omitempty" tf:"cloud_function,omitempty"`
 
-	// Reference to a Function to populate cloudFunction.
+	// Reference to a Function in cloudfunctions to populate cloudFunction.
 	// +kubebuilder:validation:Optional
 	CloudFunctionRef *v1.Reference `json:"cloudFunctionRef,omitempty" tf:"-"`
 
-	// Selector for a Function to populate cloudFunction.
+	// Selector for a Function in cloudfunctions to populate cloudFunction.
 	// +kubebuilder:validation:Optional
 	CloudFunctionSelector *v1.Selector `json:"cloudFunctionSelector,omitempty" tf:"-"`
 

--- a/apis/cloudplatform/v1beta1/zz_folderiammember_types.go
+++ b/apis/cloudplatform/v1beta1/zz_folderiammember_types.go
@@ -44,15 +44,15 @@ type ConditionParameters struct {
 type FolderIAMMemberInitParameters struct {
 	Condition []ConditionInitParameters `json:"condition,omitempty" tf:"condition,omitempty"`
 
-	// +crossplane:generate:reference:type=Folder
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/cloudplatform/v1beta1.Folder
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	Folder *string `json:"folder,omitempty" tf:"folder,omitempty"`
 
-	// Reference to a Folder to populate folder.
+	// Reference to a Folder in cloudplatform to populate folder.
 	// +kubebuilder:validation:Optional
 	FolderRef *v1.Reference `json:"folderRef,omitempty" tf:"-"`
 
-	// Selector for a Folder to populate folder.
+	// Selector for a Folder in cloudplatform to populate folder.
 	// +kubebuilder:validation:Optional
 	FolderSelector *v1.Selector `json:"folderSelector,omitempty" tf:"-"`
 
@@ -80,16 +80,16 @@ type FolderIAMMemberParameters struct {
 	// +kubebuilder:validation:Optional
 	Condition []ConditionParameters `json:"condition,omitempty" tf:"condition,omitempty"`
 
-	// +crossplane:generate:reference:type=Folder
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/cloudplatform/v1beta1.Folder
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	Folder *string `json:"folder,omitempty" tf:"folder,omitempty"`
 
-	// Reference to a Folder to populate folder.
+	// Reference to a Folder in cloudplatform to populate folder.
 	// +kubebuilder:validation:Optional
 	FolderRef *v1.Reference `json:"folderRef,omitempty" tf:"-"`
 
-	// Selector for a Folder to populate folder.
+	// Selector for a Folder in cloudplatform to populate folder.
 	// +kubebuilder:validation:Optional
 	FolderSelector *v1.Selector `json:"folderSelector,omitempty" tf:"-"`
 

--- a/apis/cloudplatform/v1beta1/zz_projectdefaultserviceaccounts_types.go
+++ b/apis/cloudplatform/v1beta1/zz_projectdefaultserviceaccounts_types.go
@@ -19,14 +19,14 @@ type ProjectDefaultServiceAccountsInitParameters struct {
 	Action *string `json:"action,omitempty" tf:"action,omitempty"`
 
 	// The project ID where service accounts are created.
-	// +crossplane:generate:reference:type=Project
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/cloudplatform/v1beta1.Project
 	Project *string `json:"project,omitempty" tf:"project,omitempty"`
 
-	// Reference to a Project to populate project.
+	// Reference to a Project in cloudplatform to populate project.
 	// +kubebuilder:validation:Optional
 	ProjectRef *v1.Reference `json:"projectRef,omitempty" tf:"-"`
 
-	// Selector for a Project to populate project.
+	// Selector for a Project in cloudplatform to populate project.
 	// +kubebuilder:validation:Optional
 	ProjectSelector *v1.Selector `json:"projectSelector,omitempty" tf:"-"`
 
@@ -65,15 +65,15 @@ type ProjectDefaultServiceAccountsParameters struct {
 	Action *string `json:"action,omitempty" tf:"action,omitempty"`
 
 	// The project ID where service accounts are created.
-	// +crossplane:generate:reference:type=Project
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/cloudplatform/v1beta1.Project
 	// +kubebuilder:validation:Optional
 	Project *string `json:"project,omitempty" tf:"project,omitempty"`
 
-	// Reference to a Project to populate project.
+	// Reference to a Project in cloudplatform to populate project.
 	// +kubebuilder:validation:Optional
 	ProjectRef *v1.Reference `json:"projectRef,omitempty" tf:"-"`
 
-	// Selector for a Project to populate project.
+	// Selector for a Project in cloudplatform to populate project.
 	// +kubebuilder:validation:Optional
 	ProjectSelector *v1.Selector `json:"projectSelector,omitempty" tf:"-"`
 

--- a/apis/cloudplatform/v1beta1/zz_projectiamauditconfig_types.go
+++ b/apis/cloudplatform/v1beta1/zz_projectiamauditconfig_types.go
@@ -42,14 +42,14 @@ type ProjectIAMAuditConfigAuditLogConfigParameters struct {
 type ProjectIAMAuditConfigInitParameters struct {
 	AuditLogConfig []ProjectIAMAuditConfigAuditLogConfigInitParameters `json:"auditLogConfig,omitempty" tf:"audit_log_config,omitempty"`
 
-	// +crossplane:generate:reference:type=Project
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/cloudplatform/v1beta1.Project
 	Project *string `json:"project,omitempty" tf:"project,omitempty"`
 
-	// Reference to a Project to populate project.
+	// Reference to a Project in cloudplatform to populate project.
 	// +kubebuilder:validation:Optional
 	ProjectRef *v1.Reference `json:"projectRef,omitempty" tf:"-"`
 
-	// Selector for a Project to populate project.
+	// Selector for a Project in cloudplatform to populate project.
 	// +kubebuilder:validation:Optional
 	ProjectSelector *v1.Selector `json:"projectSelector,omitempty" tf:"-"`
 
@@ -73,15 +73,15 @@ type ProjectIAMAuditConfigParameters struct {
 	// +kubebuilder:validation:Optional
 	AuditLogConfig []ProjectIAMAuditConfigAuditLogConfigParameters `json:"auditLogConfig,omitempty" tf:"audit_log_config,omitempty"`
 
-	// +crossplane:generate:reference:type=Project
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/cloudplatform/v1beta1.Project
 	// +kubebuilder:validation:Optional
 	Project *string `json:"project,omitempty" tf:"project,omitempty"`
 
-	// Reference to a Project to populate project.
+	// Reference to a Project in cloudplatform to populate project.
 	// +kubebuilder:validation:Optional
 	ProjectRef *v1.Reference `json:"projectRef,omitempty" tf:"-"`
 
-	// Selector for a Project to populate project.
+	// Selector for a Project in cloudplatform to populate project.
 	// +kubebuilder:validation:Optional
 	ProjectSelector *v1.Selector `json:"projectSelector,omitempty" tf:"-"`
 

--- a/apis/cloudplatform/v1beta1/zz_projectiammember_types.go
+++ b/apis/cloudplatform/v1beta1/zz_projectiammember_types.go
@@ -46,14 +46,14 @@ type ProjectIAMMemberInitParameters struct {
 
 	Member *string `json:"member,omitempty" tf:"member,omitempty"`
 
-	// +crossplane:generate:reference:type=Project
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/cloudplatform/v1beta1.Project
 	Project *string `json:"project,omitempty" tf:"project,omitempty"`
 
-	// Reference to a Project to populate project.
+	// Reference to a Project in cloudplatform to populate project.
 	// +kubebuilder:validation:Optional
 	ProjectRef *v1.Reference `json:"projectRef,omitempty" tf:"-"`
 
-	// Selector for a Project to populate project.
+	// Selector for a Project in cloudplatform to populate project.
 	// +kubebuilder:validation:Optional
 	ProjectSelector *v1.Selector `json:"projectSelector,omitempty" tf:"-"`
 
@@ -82,15 +82,15 @@ type ProjectIAMMemberParameters struct {
 	// +kubebuilder:validation:Optional
 	Member *string `json:"member,omitempty" tf:"member,omitempty"`
 
-	// +crossplane:generate:reference:type=Project
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/cloudplatform/v1beta1.Project
 	// +kubebuilder:validation:Optional
 	Project *string `json:"project,omitempty" tf:"project,omitempty"`
 
-	// Reference to a Project to populate project.
+	// Reference to a Project in cloudplatform to populate project.
 	// +kubebuilder:validation:Optional
 	ProjectRef *v1.Reference `json:"projectRef,omitempty" tf:"-"`
 
-	// Selector for a Project to populate project.
+	// Selector for a Project in cloudplatform to populate project.
 	// +kubebuilder:validation:Optional
 	ProjectSelector *v1.Selector `json:"projectSelector,omitempty" tf:"-"`
 

--- a/apis/cloudplatform/v1beta1/zz_projectservice_types.go
+++ b/apis/cloudplatform/v1beta1/zz_projectservice_types.go
@@ -28,14 +28,14 @@ type ProjectServiceInitParameters struct {
 
 	// The project ID. If not provided, the provider project
 	// is used.
-	// +crossplane:generate:reference:type=Project
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/cloudplatform/v1beta1.Project
 	Project *string `json:"project,omitempty" tf:"project,omitempty"`
 
-	// Reference to a Project to populate project.
+	// Reference to a Project in cloudplatform to populate project.
 	// +kubebuilder:validation:Optional
 	ProjectRef *v1.Reference `json:"projectRef,omitempty" tf:"-"`
 
-	// Selector for a Project to populate project.
+	// Selector for a Project in cloudplatform to populate project.
 	// +kubebuilder:validation:Optional
 	ProjectSelector *v1.Selector `json:"projectSelector,omitempty" tf:"-"`
 
@@ -84,15 +84,15 @@ type ProjectServiceParameters struct {
 
 	// The project ID. If not provided, the provider project
 	// is used.
-	// +crossplane:generate:reference:type=Project
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/cloudplatform/v1beta1.Project
 	// +kubebuilder:validation:Optional
 	Project *string `json:"project,omitempty" tf:"project,omitempty"`
 
-	// Reference to a Project to populate project.
+	// Reference to a Project in cloudplatform to populate project.
 	// +kubebuilder:validation:Optional
 	ProjectRef *v1.Reference `json:"projectRef,omitempty" tf:"-"`
 
-	// Selector for a Project to populate project.
+	// Selector for a Project in cloudplatform to populate project.
 	// +kubebuilder:validation:Optional
 	ProjectSelector *v1.Selector `json:"projectSelector,omitempty" tf:"-"`
 

--- a/apis/cloudplatform/v1beta1/zz_projectusageexportbucket_types.go
+++ b/apis/cloudplatform/v1beta1/zz_projectusageexportbucket_types.go
@@ -31,14 +31,14 @@ type ProjectUsageExportBucketInitParameters struct {
 	Prefix *string `json:"prefix,omitempty" tf:"prefix,omitempty"`
 
 	// :  The project to set the export bucket on. If it is not provided, the provider project is used.
-	// +crossplane:generate:reference:type=Project
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/cloudplatform/v1beta1.Project
 	Project *string `json:"project,omitempty" tf:"project,omitempty"`
 
-	// Reference to a Project to populate project.
+	// Reference to a Project in cloudplatform to populate project.
 	// +kubebuilder:validation:Optional
 	ProjectRef *v1.Reference `json:"projectRef,omitempty" tf:"-"`
 
-	// Selector for a Project to populate project.
+	// Selector for a Project in cloudplatform to populate project.
 	// +kubebuilder:validation:Optional
 	ProjectSelector *v1.Selector `json:"projectSelector,omitempty" tf:"-"`
 }
@@ -77,15 +77,15 @@ type ProjectUsageExportBucketParameters struct {
 	Prefix *string `json:"prefix,omitempty" tf:"prefix,omitempty"`
 
 	// :  The project to set the export bucket on. If it is not provided, the provider project is used.
-	// +crossplane:generate:reference:type=Project
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/cloudplatform/v1beta1.Project
 	// +kubebuilder:validation:Optional
 	Project *string `json:"project,omitempty" tf:"project,omitempty"`
 
-	// Reference to a Project to populate project.
+	// Reference to a Project in cloudplatform to populate project.
 	// +kubebuilder:validation:Optional
 	ProjectRef *v1.Reference `json:"projectRef,omitempty" tf:"-"`
 
-	// Selector for a Project to populate project.
+	// Selector for a Project in cloudplatform to populate project.
 	// +kubebuilder:validation:Optional
 	ProjectSelector *v1.Selector `json:"projectSelector,omitempty" tf:"-"`
 }

--- a/apis/cloudplatform/v1beta1/zz_serviceaccountiammember_types.go
+++ b/apis/cloudplatform/v1beta1/zz_serviceaccountiammember_types.go
@@ -48,15 +48,15 @@ type ServiceAccountIAMMemberInitParameters struct {
 
 	Role *string `json:"role,omitempty" tf:"role,omitempty"`
 
-	// +crossplane:generate:reference:type=ServiceAccount
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/cloudplatform/v1beta1.ServiceAccount
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	ServiceAccountID *string `json:"serviceAccountId,omitempty" tf:"service_account_id,omitempty"`
 
-	// Reference to a ServiceAccount to populate serviceAccountId.
+	// Reference to a ServiceAccount in cloudplatform to populate serviceAccountId.
 	// +kubebuilder:validation:Optional
 	ServiceAccountIDRef *v1.Reference `json:"serviceAccountIdRef,omitempty" tf:"-"`
 
-	// Selector for a ServiceAccount to populate serviceAccountId.
+	// Selector for a ServiceAccount in cloudplatform to populate serviceAccountId.
 	// +kubebuilder:validation:Optional
 	ServiceAccountIDSelector *v1.Selector `json:"serviceAccountIdSelector,omitempty" tf:"-"`
 }
@@ -86,16 +86,16 @@ type ServiceAccountIAMMemberParameters struct {
 	// +kubebuilder:validation:Optional
 	Role *string `json:"role,omitempty" tf:"role,omitempty"`
 
-	// +crossplane:generate:reference:type=ServiceAccount
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/cloudplatform/v1beta1.ServiceAccount
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	ServiceAccountID *string `json:"serviceAccountId,omitempty" tf:"service_account_id,omitempty"`
 
-	// Reference to a ServiceAccount to populate serviceAccountId.
+	// Reference to a ServiceAccount in cloudplatform to populate serviceAccountId.
 	// +kubebuilder:validation:Optional
 	ServiceAccountIDRef *v1.Reference `json:"serviceAccountIdRef,omitempty" tf:"-"`
 
-	// Selector for a ServiceAccount to populate serviceAccountId.
+	// Selector for a ServiceAccount in cloudplatform to populate serviceAccountId.
 	// +kubebuilder:validation:Optional
 	ServiceAccountIDSelector *v1.Selector `json:"serviceAccountIdSelector,omitempty" tf:"-"`
 }

--- a/apis/cloudplatform/v1beta1/zz_serviceaccountkey_types.go
+++ b/apis/cloudplatform/v1beta1/zz_serviceaccountkey_types.go
@@ -39,15 +39,15 @@ type ServiceAccountKeyInitParameters struct {
 	// automatically be inferred from the account. Otherwise, if the projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}
 	// syntax is used, the {ACCOUNT} specified can be the full email address of the service account or the service account's
 	// unique id. Substituting - as a wildcard for the {PROJECT_ID} will infer the project from the account.
-	// +crossplane:generate:reference:type=ServiceAccount
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/cloudplatform/v1beta1.ServiceAccount
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	ServiceAccountID *string `json:"serviceAccountId,omitempty" tf:"service_account_id,omitempty"`
 
-	// Reference to a ServiceAccount to populate serviceAccountId.
+	// Reference to a ServiceAccount in cloudplatform to populate serviceAccountId.
 	// +kubebuilder:validation:Optional
 	ServiceAccountIDRef *v1.Reference `json:"serviceAccountIdRef,omitempty" tf:"-"`
 
-	// Selector for a ServiceAccount to populate serviceAccountId.
+	// Selector for a ServiceAccount in cloudplatform to populate serviceAccountId.
 	// +kubebuilder:validation:Optional
 	ServiceAccountIDSelector *v1.Selector `json:"serviceAccountIdSelector,omitempty" tf:"-"`
 }
@@ -128,16 +128,16 @@ type ServiceAccountKeyParameters struct {
 	// automatically be inferred from the account. Otherwise, if the projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}
 	// syntax is used, the {ACCOUNT} specified can be the full email address of the service account or the service account's
 	// unique id. Substituting - as a wildcard for the {PROJECT_ID} will infer the project from the account.
-	// +crossplane:generate:reference:type=ServiceAccount
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/cloudplatform/v1beta1.ServiceAccount
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	ServiceAccountID *string `json:"serviceAccountId,omitempty" tf:"service_account_id,omitempty"`
 
-	// Reference to a ServiceAccount to populate serviceAccountId.
+	// Reference to a ServiceAccount in cloudplatform to populate serviceAccountId.
 	// +kubebuilder:validation:Optional
 	ServiceAccountIDRef *v1.Reference `json:"serviceAccountIdRef,omitempty" tf:"-"`
 
-	// Selector for a ServiceAccount to populate serviceAccountId.
+	// Selector for a ServiceAccount in cloudplatform to populate serviceAccountId.
 	// +kubebuilder:validation:Optional
 	ServiceAccountIDSelector *v1.Selector `json:"serviceAccountIdSelector,omitempty" tf:"-"`
 }

--- a/apis/cloudrun/v1beta1/zz_domainmapping_types.go
+++ b/apis/cloudrun/v1beta1/zz_domainmapping_types.go
@@ -283,14 +283,14 @@ type SpecInitParameters struct {
 
 	// The name of the Cloud Run Service that this DomainMapping applies to.
 	// The route must exist.
-	// +crossplane:generate:reference:type=Service
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/cloudrun/v1beta1.Service
 	RouteName *string `json:"routeName,omitempty" tf:"route_name,omitempty"`
 
-	// Reference to a Service to populate routeName.
+	// Reference to a Service in cloudrun to populate routeName.
 	// +kubebuilder:validation:Optional
 	RouteNameRef *v1.Reference `json:"routeNameRef,omitempty" tf:"-"`
 
-	// Selector for a Service to populate routeName.
+	// Selector for a Service in cloudrun to populate routeName.
 	// +kubebuilder:validation:Optional
 	RouteNameSelector *v1.Selector `json:"routeNameSelector,omitempty" tf:"-"`
 }
@@ -330,15 +330,15 @@ type SpecParameters struct {
 
 	// The name of the Cloud Run Service that this DomainMapping applies to.
 	// The route must exist.
-	// +crossplane:generate:reference:type=Service
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/cloudrun/v1beta1.Service
 	// +kubebuilder:validation:Optional
 	RouteName *string `json:"routeName,omitempty" tf:"route_name,omitempty"`
 
-	// Reference to a Service to populate routeName.
+	// Reference to a Service in cloudrun to populate routeName.
 	// +kubebuilder:validation:Optional
 	RouteNameRef *v1.Reference `json:"routeNameRef,omitempty" tf:"-"`
 
-	// Selector for a Service to populate routeName.
+	// Selector for a Service in cloudrun to populate routeName.
 	// +kubebuilder:validation:Optional
 	RouteNameSelector *v1.Selector `json:"routeNameSelector,omitempty" tf:"-"`
 }

--- a/apis/cloudrun/v1beta1/zz_serviceiammember_types.go
+++ b/apis/cloudrun/v1beta1/zz_serviceiammember_types.go
@@ -61,14 +61,14 @@ type ServiceIAMMemberInitParameters struct {
 
 	Role *string `json:"role,omitempty" tf:"role,omitempty"`
 
-	// +crossplane:generate:reference:type=Service
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/cloudrun/v1beta1.Service
 	Service *string `json:"service,omitempty" tf:"service,omitempty"`
 
-	// Reference to a Service to populate service.
+	// Reference to a Service in cloudrun to populate service.
 	// +kubebuilder:validation:Optional
 	ServiceRef *v1.Reference `json:"serviceRef,omitempty" tf:"-"`
 
-	// Selector for a Service to populate service.
+	// Selector for a Service in cloudrun to populate service.
 	// +kubebuilder:validation:Optional
 	ServiceSelector *v1.Selector `json:"serviceSelector,omitempty" tf:"-"`
 }
@@ -117,15 +117,15 @@ type ServiceIAMMemberParameters struct {
 	// +kubebuilder:validation:Optional
 	Role *string `json:"role,omitempty" tf:"role,omitempty"`
 
-	// +crossplane:generate:reference:type=Service
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/cloudrun/v1beta1.Service
 	// +kubebuilder:validation:Optional
 	Service *string `json:"service,omitempty" tf:"service,omitempty"`
 
-	// Reference to a Service to populate service.
+	// Reference to a Service in cloudrun to populate service.
 	// +kubebuilder:validation:Optional
 	ServiceRef *v1.Reference `json:"serviceRef,omitempty" tf:"-"`
 
-	// Selector for a Service to populate service.
+	// Selector for a Service in cloudrun to populate service.
 	// +kubebuilder:validation:Optional
 	ServiceSelector *v1.Selector `json:"serviceSelector,omitempty" tf:"-"`
 }

--- a/apis/compute/v1beta1/zz_address_types.go
+++ b/apis/compute/v1beta1/zz_address_types.go
@@ -46,15 +46,15 @@ type AddressInitParameters struct {
 	// The URL of the network in which to reserve the address. This field
 	// can only be used with INTERNAL type with the VPC_PEERING and
 	// IPSEC_INTERCONNECT purposes.
-	// +crossplane:generate:reference:type=Network
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Network
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	Network *string `json:"network,omitempty" tf:"network,omitempty"`
 
-	// Reference to a Network to populate network.
+	// Reference to a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkRef *v1.Reference `json:"networkRef,omitempty" tf:"-"`
 
-	// Selector for a Network to populate network.
+	// Selector for a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkSelector *v1.Selector `json:"networkSelector,omitempty" tf:"-"`
 
@@ -78,15 +78,15 @@ type AddressInitParameters struct {
 	// address is specified, it must be within the subnetwork's IP range.
 	// This field can only be used with INTERNAL type with
 	// GCE_ENDPOINT/DNS_RESOLVER purposes.
-	// +crossplane:generate:reference:type=Subnetwork
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Subnetwork
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	Subnetwork *string `json:"subnetwork,omitempty" tf:"subnetwork,omitempty"`
 
-	// Reference to a Subnetwork to populate subnetwork.
+	// Reference to a Subnetwork in compute to populate subnetwork.
 	// +kubebuilder:validation:Optional
 	SubnetworkRef *v1.Reference `json:"subnetworkRef,omitempty" tf:"-"`
 
-	// Selector for a Subnetwork to populate subnetwork.
+	// Selector for a Subnetwork in compute to populate subnetwork.
 	// +kubebuilder:validation:Optional
 	SubnetworkSelector *v1.Selector `json:"subnetworkSelector,omitempty" tf:"-"`
 }
@@ -217,16 +217,16 @@ type AddressParameters struct {
 	// The URL of the network in which to reserve the address. This field
 	// can only be used with INTERNAL type with the VPC_PEERING and
 	// IPSEC_INTERCONNECT purposes.
-	// +crossplane:generate:reference:type=Network
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Network
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	// +kubebuilder:validation:Optional
 	Network *string `json:"network,omitempty" tf:"network,omitempty"`
 
-	// Reference to a Network to populate network.
+	// Reference to a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkRef *v1.Reference `json:"networkRef,omitempty" tf:"-"`
 
-	// Selector for a Network to populate network.
+	// Selector for a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkSelector *v1.Selector `json:"networkSelector,omitempty" tf:"-"`
 
@@ -259,16 +259,16 @@ type AddressParameters struct {
 	// address is specified, it must be within the subnetwork's IP range.
 	// This field can only be used with INTERNAL type with
 	// GCE_ENDPOINT/DNS_RESOLVER purposes.
-	// +crossplane:generate:reference:type=Subnetwork
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Subnetwork
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	// +kubebuilder:validation:Optional
 	Subnetwork *string `json:"subnetwork,omitempty" tf:"subnetwork,omitempty"`
 
-	// Reference to a Subnetwork to populate subnetwork.
+	// Reference to a Subnetwork in compute to populate subnetwork.
 	// +kubebuilder:validation:Optional
 	SubnetworkRef *v1.Reference `json:"subnetworkRef,omitempty" tf:"-"`
 
-	// Selector for a Subnetwork to populate subnetwork.
+	// Selector for a Subnetwork in compute to populate subnetwork.
 	// +kubebuilder:validation:Optional
 	SubnetworkSelector *v1.Selector `json:"subnetworkSelector,omitempty" tf:"-"`
 }

--- a/apis/compute/v1beta1/zz_backendservice_types.go
+++ b/apis/compute/v1beta1/zz_backendservice_types.go
@@ -51,15 +51,15 @@ type BackendInitParameters struct {
 	// Note that you must specify an Instance Group or Network Endpoint
 	// Group resource using the fully-qualified URL, rather than a
 	// partial URL.
-	// +crossplane:generate:reference:type=InstanceGroupManager
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.InstanceGroupManager
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/compute.InstanceGroupExtractor()
 	Group *string `json:"group,omitempty" tf:"group,omitempty"`
 
-	// Reference to a InstanceGroupManager to populate group.
+	// Reference to a InstanceGroupManager in compute to populate group.
 	// +kubebuilder:validation:Optional
 	GroupRef *v1.Reference `json:"groupRef,omitempty" tf:"-"`
 
-	// Selector for a InstanceGroupManager to populate group.
+	// Selector for a InstanceGroupManager in compute to populate group.
 	// +kubebuilder:validation:Optional
 	GroupSelector *v1.Selector `json:"groupSelector,omitempty" tf:"-"`
 
@@ -238,16 +238,16 @@ type BackendParameters struct {
 	// Note that you must specify an Instance Group or Network Endpoint
 	// Group resource using the fully-qualified URL, rather than a
 	// partial URL.
-	// +crossplane:generate:reference:type=InstanceGroupManager
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.InstanceGroupManager
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/compute.InstanceGroupExtractor()
 	// +kubebuilder:validation:Optional
 	Group *string `json:"group,omitempty" tf:"group,omitempty"`
 
-	// Reference to a InstanceGroupManager to populate group.
+	// Reference to a InstanceGroupManager in compute to populate group.
 	// +kubebuilder:validation:Optional
 	GroupRef *v1.Reference `json:"groupRef,omitempty" tf:"-"`
 
-	// Selector for a InstanceGroupManager to populate group.
+	// Selector for a InstanceGroupManager in compute to populate group.
 	// +kubebuilder:validation:Optional
 	GroupSelector *v1.Selector `json:"groupSelector,omitempty" tf:"-"`
 
@@ -528,16 +528,16 @@ type BackendServiceInitParameters struct {
 	// A health check must be specified unless the backend service uses an internet
 	// or serverless NEG as a backend.
 	// For internal load balancing, a URL to a HealthCheck resource must be specified instead.
-	// +crossplane:generate:reference:type=HealthCheck
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.HealthCheck
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	// +listType=set
 	HealthChecks []*string `json:"healthChecks,omitempty" tf:"health_checks,omitempty"`
 
-	// References to HealthCheck to populate healthChecks.
+	// References to HealthCheck in compute to populate healthChecks.
 	// +kubebuilder:validation:Optional
 	HealthChecksRefs []v1.Reference `json:"healthChecksRefs,omitempty" tf:"-"`
 
-	// Selector for a list of HealthCheck to populate healthChecks.
+	// Selector for a list of HealthCheck in compute to populate healthChecks.
 	// +kubebuilder:validation:Optional
 	HealthChecksSelector *v1.Selector `json:"healthChecksSelector,omitempty" tf:"-"`
 
@@ -850,17 +850,17 @@ type BackendServiceParameters struct {
 	// A health check must be specified unless the backend service uses an internet
 	// or serverless NEG as a backend.
 	// For internal load balancing, a URL to a HealthCheck resource must be specified instead.
-	// +crossplane:generate:reference:type=HealthCheck
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.HealthCheck
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	// +kubebuilder:validation:Optional
 	// +listType=set
 	HealthChecks []*string `json:"healthChecks,omitempty" tf:"health_checks,omitempty"`
 
-	// References to HealthCheck to populate healthChecks.
+	// References to HealthCheck in compute to populate healthChecks.
 	// +kubebuilder:validation:Optional
 	HealthChecksRefs []v1.Reference `json:"healthChecksRefs,omitempty" tf:"-"`
 
-	// Selector for a list of HealthCheck to populate healthChecks.
+	// Selector for a list of HealthCheck in compute to populate healthChecks.
 	// +kubebuilder:validation:Optional
 	HealthChecksSelector *v1.Selector `json:"healthChecksSelector,omitempty" tf:"-"`
 

--- a/apis/compute/v1beta1/zz_diskiammember_types.go
+++ b/apis/compute/v1beta1/zz_diskiammember_types.go
@@ -46,14 +46,14 @@ type DiskIAMMemberInitParameters struct {
 
 	Member *string `json:"member,omitempty" tf:"member,omitempty"`
 
-	// +crossplane:generate:reference:type=Disk
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Disk
 	Name *string `json:"name,omitempty" tf:"name,omitempty"`
 
-	// Reference to a Disk to populate name.
+	// Reference to a Disk in compute to populate name.
 	// +kubebuilder:validation:Optional
 	NameRef *v1.Reference `json:"nameRef,omitempty" tf:"-"`
 
-	// Selector for a Disk to populate name.
+	// Selector for a Disk in compute to populate name.
 	// +kubebuilder:validation:Optional
 	NameSelector *v1.Selector `json:"nameSelector,omitempty" tf:"-"`
 
@@ -90,15 +90,15 @@ type DiskIAMMemberParameters struct {
 	// +kubebuilder:validation:Optional
 	Member *string `json:"member,omitempty" tf:"member,omitempty"`
 
-	// +crossplane:generate:reference:type=Disk
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Disk
 	// +kubebuilder:validation:Optional
 	Name *string `json:"name,omitempty" tf:"name,omitempty"`
 
-	// Reference to a Disk to populate name.
+	// Reference to a Disk in compute to populate name.
 	// +kubebuilder:validation:Optional
 	NameRef *v1.Reference `json:"nameRef,omitempty" tf:"-"`
 
-	// Selector for a Disk to populate name.
+	// Selector for a Disk in compute to populate name.
 	// +kubebuilder:validation:Optional
 	NameSelector *v1.Selector `json:"nameSelector,omitempty" tf:"-"`
 

--- a/apis/compute/v1beta1/zz_firewall_types.go
+++ b/apis/compute/v1beta1/zz_firewall_types.go
@@ -164,15 +164,15 @@ type FirewallInitParameters struct {
 	LogConfig []FirewallLogConfigInitParameters `json:"logConfig,omitempty" tf:"log_config,omitempty"`
 
 	// The name or self_link of the network to attach this firewall to.
-	// +crossplane:generate:reference:type=Network
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Network
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	Network *string `json:"network,omitempty" tf:"network,omitempty"`
 
-	// Reference to a Network to populate network.
+	// Reference to a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkRef *v1.Reference `json:"networkRef,omitempty" tf:"-"`
 
-	// Selector for a Network to populate network.
+	// Selector for a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkSelector *v1.Selector `json:"networkSelector,omitempty" tf:"-"`
 
@@ -445,16 +445,16 @@ type FirewallParameters struct {
 	LogConfig []FirewallLogConfigParameters `json:"logConfig,omitempty" tf:"log_config,omitempty"`
 
 	// The name or self_link of the network to attach this firewall to.
-	// +crossplane:generate:reference:type=Network
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Network
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	// +kubebuilder:validation:Optional
 	Network *string `json:"network,omitempty" tf:"network,omitempty"`
 
-	// Reference to a Network to populate network.
+	// Reference to a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkRef *v1.Reference `json:"networkRef,omitempty" tf:"-"`
 
-	// Selector for a Network to populate network.
+	// Selector for a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkSelector *v1.Selector `json:"networkSelector,omitempty" tf:"-"`
 

--- a/apis/compute/v1beta1/zz_forwardingrule_types.go
+++ b/apis/compute/v1beta1/zz_forwardingrule_types.go
@@ -36,15 +36,15 @@ type ForwardingRuleInitParameters struct {
 	// Identifies the backend service to which the forwarding rule sends traffic.
 	// Required for Internal TCP/UDP Load Balancing and Network Load Balancing;
 	// must be omitted for all other load balancer types.
-	// +crossplane:generate:reference:type=RegionBackendService
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.RegionBackendService
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	BackendService *string `json:"backendService,omitempty" tf:"backend_service,omitempty"`
 
-	// Reference to a RegionBackendService to populate backendService.
+	// Reference to a RegionBackendService in compute to populate backendService.
 	// +kubebuilder:validation:Optional
 	BackendServiceRef *v1.Reference `json:"backendServiceRef,omitempty" tf:"-"`
 
-	// Selector for a RegionBackendService to populate backendService.
+	// Selector for a RegionBackendService in compute to populate backendService.
 	// +kubebuilder:validation:Optional
 	BackendServiceSelector *v1.Selector `json:"backendServiceSelector,omitempty" tf:"-"`
 
@@ -57,15 +57,15 @@ type ForwardingRuleInitParameters struct {
 	// to the referenced target or backendService.
 	// While creating a forwarding rule, specifying an IPAddress is
 	// required under the following circumstances:
-	// +crossplane:generate:reference:type=Address
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Address
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	IPAddress *string `json:"ipAddress,omitempty" tf:"ip_address,omitempty"`
 
-	// Reference to a Address to populate ipAddress.
+	// Reference to a Address in compute to populate ipAddress.
 	// +kubebuilder:validation:Optional
 	IPAddressRef *v1.Reference `json:"ipAddressRef,omitempty" tf:"-"`
 
-	// Selector for a Address to populate ipAddress.
+	// Selector for a Address in compute to populate ipAddress.
 	// +kubebuilder:validation:Optional
 	IPAddressSelector *v1.Selector `json:"ipAddressSelector,omitempty" tf:"-"`
 
@@ -116,15 +116,15 @@ type ForwardingRuleInitParameters struct {
 	// be used.
 	// For Private Service Connect forwarding rules that forward traffic to Google
 	// APIs, a network must be provided.
-	// +crossplane:generate:reference:type=Network
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Network
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	Network *string `json:"network,omitempty" tf:"network,omitempty"`
 
-	// Reference to a Network to populate network.
+	// Reference to a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkRef *v1.Reference `json:"networkRef,omitempty" tf:"-"`
 
-	// Selector for a Network to populate network.
+	// Selector for a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkSelector *v1.Selector `json:"networkSelector,omitempty" tf:"-"`
 
@@ -189,30 +189,30 @@ type ForwardingRuleInitParameters struct {
 	// If the network specified is in auto subnet mode, this field is optional.
 	// However, a subnetwork must be specified if the network is in custom subnet
 	// mode or when creating external forwarding rule with IPv6.
-	// +crossplane:generate:reference:type=Subnetwork
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Subnetwork
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	Subnetwork *string `json:"subnetwork,omitempty" tf:"subnetwork,omitempty"`
 
-	// Reference to a Subnetwork to populate subnetwork.
+	// Reference to a Subnetwork in compute to populate subnetwork.
 	// +kubebuilder:validation:Optional
 	SubnetworkRef *v1.Reference `json:"subnetworkRef,omitempty" tf:"-"`
 
-	// Selector for a Subnetwork to populate subnetwork.
+	// Selector for a Subnetwork in compute to populate subnetwork.
 	// +kubebuilder:validation:Optional
 	SubnetworkSelector *v1.Selector `json:"subnetworkSelector,omitempty" tf:"-"`
 
 	// is set to targetGrpcProxy and
 	// validateForProxyless is set to true, the
 	// IPAddress should be set to 0.0.0.0.
-	// +crossplane:generate:reference:type=RegionTargetHTTPProxy
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.RegionTargetHTTPProxy
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	Target *string `json:"target,omitempty" tf:"target,omitempty"`
 
-	// Reference to a RegionTargetHTTPProxy to populate target.
+	// Reference to a RegionTargetHTTPProxy in compute to populate target.
 	// +kubebuilder:validation:Optional
 	TargetRef *v1.Reference `json:"targetRef,omitempty" tf:"-"`
 
-	// Selector for a RegionTargetHTTPProxy to populate target.
+	// Selector for a RegionTargetHTTPProxy in compute to populate target.
 	// +kubebuilder:validation:Optional
 	TargetSelector *v1.Selector `json:"targetSelector,omitempty" tf:"-"`
 }
@@ -436,16 +436,16 @@ type ForwardingRuleParameters struct {
 	// Identifies the backend service to which the forwarding rule sends traffic.
 	// Required for Internal TCP/UDP Load Balancing and Network Load Balancing;
 	// must be omitted for all other load balancer types.
-	// +crossplane:generate:reference:type=RegionBackendService
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.RegionBackendService
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	// +kubebuilder:validation:Optional
 	BackendService *string `json:"backendService,omitempty" tf:"backend_service,omitempty"`
 
-	// Reference to a RegionBackendService to populate backendService.
+	// Reference to a RegionBackendService in compute to populate backendService.
 	// +kubebuilder:validation:Optional
 	BackendServiceRef *v1.Reference `json:"backendServiceRef,omitempty" tf:"-"`
 
-	// Selector for a RegionBackendService to populate backendService.
+	// Selector for a RegionBackendService in compute to populate backendService.
 	// +kubebuilder:validation:Optional
 	BackendServiceSelector *v1.Selector `json:"backendServiceSelector,omitempty" tf:"-"`
 
@@ -459,16 +459,16 @@ type ForwardingRuleParameters struct {
 	// to the referenced target or backendService.
 	// While creating a forwarding rule, specifying an IPAddress is
 	// required under the following circumstances:
-	// +crossplane:generate:reference:type=Address
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Address
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	// +kubebuilder:validation:Optional
 	IPAddress *string `json:"ipAddress,omitempty" tf:"ip_address,omitempty"`
 
-	// Reference to a Address to populate ipAddress.
+	// Reference to a Address in compute to populate ipAddress.
 	// +kubebuilder:validation:Optional
 	IPAddressRef *v1.Reference `json:"ipAddressRef,omitempty" tf:"-"`
 
-	// Selector for a Address to populate ipAddress.
+	// Selector for a Address in compute to populate ipAddress.
 	// +kubebuilder:validation:Optional
 	IPAddressSelector *v1.Selector `json:"ipAddressSelector,omitempty" tf:"-"`
 
@@ -524,16 +524,16 @@ type ForwardingRuleParameters struct {
 	// be used.
 	// For Private Service Connect forwarding rules that forward traffic to Google
 	// APIs, a network must be provided.
-	// +crossplane:generate:reference:type=Network
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Network
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	// +kubebuilder:validation:Optional
 	Network *string `json:"network,omitempty" tf:"network,omitempty"`
 
-	// Reference to a Network to populate network.
+	// Reference to a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkRef *v1.Reference `json:"networkRef,omitempty" tf:"-"`
 
-	// Selector for a Network to populate network.
+	// Selector for a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkSelector *v1.Selector `json:"networkSelector,omitempty" tf:"-"`
 
@@ -612,32 +612,32 @@ type ForwardingRuleParameters struct {
 	// If the network specified is in auto subnet mode, this field is optional.
 	// However, a subnetwork must be specified if the network is in custom subnet
 	// mode or when creating external forwarding rule with IPv6.
-	// +crossplane:generate:reference:type=Subnetwork
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Subnetwork
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	// +kubebuilder:validation:Optional
 	Subnetwork *string `json:"subnetwork,omitempty" tf:"subnetwork,omitempty"`
 
-	// Reference to a Subnetwork to populate subnetwork.
+	// Reference to a Subnetwork in compute to populate subnetwork.
 	// +kubebuilder:validation:Optional
 	SubnetworkRef *v1.Reference `json:"subnetworkRef,omitempty" tf:"-"`
 
-	// Selector for a Subnetwork to populate subnetwork.
+	// Selector for a Subnetwork in compute to populate subnetwork.
 	// +kubebuilder:validation:Optional
 	SubnetworkSelector *v1.Selector `json:"subnetworkSelector,omitempty" tf:"-"`
 
 	// is set to targetGrpcProxy and
 	// validateForProxyless is set to true, the
 	// IPAddress should be set to 0.0.0.0.
-	// +crossplane:generate:reference:type=RegionTargetHTTPProxy
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.RegionTargetHTTPProxy
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	// +kubebuilder:validation:Optional
 	Target *string `json:"target,omitempty" tf:"target,omitempty"`
 
-	// Reference to a RegionTargetHTTPProxy to populate target.
+	// Reference to a RegionTargetHTTPProxy in compute to populate target.
 	// +kubebuilder:validation:Optional
 	TargetRef *v1.Reference `json:"targetRef,omitempty" tf:"-"`
 
-	// Selector for a RegionTargetHTTPProxy to populate target.
+	// Selector for a RegionTargetHTTPProxy in compute to populate target.
 	// +kubebuilder:validation:Optional
 	TargetSelector *v1.Selector `json:"targetSelector,omitempty" tf:"-"`
 }

--- a/apis/compute/v1beta1/zz_globaladdress_types.go
+++ b/apis/compute/v1beta1/zz_globaladdress_types.go
@@ -34,15 +34,15 @@ type GlobalAddressInitParameters struct {
 	// must be in RFC1918 space. The network cannot be deleted if there are
 	// any reserved IP ranges referring to it.
 	// This should only be set when using an Internal address.
-	// +crossplane:generate:reference:type=Network
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Network
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	Network *string `json:"network,omitempty" tf:"network,omitempty"`
 
-	// Reference to a Network to populate network.
+	// Reference to a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkRef *v1.Reference `json:"networkRef,omitempty" tf:"-"`
 
-	// Selector for a Network to populate network.
+	// Selector for a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkSelector *v1.Selector `json:"networkSelector,omitempty" tf:"-"`
 
@@ -131,16 +131,16 @@ type GlobalAddressParameters struct {
 	// must be in RFC1918 space. The network cannot be deleted if there are
 	// any reserved IP ranges referring to it.
 	// This should only be set when using an Internal address.
-	// +crossplane:generate:reference:type=Network
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Network
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	Network *string `json:"network,omitempty" tf:"network,omitempty"`
 
-	// Reference to a Network to populate network.
+	// Reference to a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkRef *v1.Reference `json:"networkRef,omitempty" tf:"-"`
 
-	// Selector for a Network to populate network.
+	// Selector for a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkSelector *v1.Selector `json:"networkSelector,omitempty" tf:"-"`
 

--- a/apis/compute/v1beta1/zz_havpngateway_types.go
+++ b/apis/compute/v1beta1/zz_havpngateway_types.go
@@ -19,15 +19,15 @@ type HaVPNGatewayInitParameters struct {
 	Description *string `json:"description,omitempty" tf:"description,omitempty"`
 
 	// The network this VPN gateway is accepting traffic for.
-	// +crossplane:generate:reference:type=Network
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Network
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	Network *string `json:"network,omitempty" tf:"network,omitempty"`
 
-	// Reference to a Network to populate network.
+	// Reference to a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkRef *v1.Reference `json:"networkRef,omitempty" tf:"-"`
 
-	// Selector for a Network to populate network.
+	// Selector for a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkSelector *v1.Selector `json:"networkSelector,omitempty" tf:"-"`
 
@@ -85,16 +85,16 @@ type HaVPNGatewayParameters struct {
 	Description *string `json:"description,omitempty" tf:"description,omitempty"`
 
 	// The network this VPN gateway is accepting traffic for.
-	// +crossplane:generate:reference:type=Network
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Network
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	Network *string `json:"network,omitempty" tf:"network,omitempty"`
 
-	// Reference to a Network to populate network.
+	// Reference to a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkRef *v1.Reference `json:"networkRef,omitempty" tf:"-"`
 
-	// Selector for a Network to populate network.
+	// Selector for a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkSelector *v1.Selector `json:"networkSelector,omitempty" tf:"-"`
 

--- a/apis/compute/v1beta1/zz_imageiammember_types.go
+++ b/apis/compute/v1beta1/zz_imageiammember_types.go
@@ -44,14 +44,14 @@ type ImageIAMMemberConditionParameters struct {
 type ImageIAMMemberInitParameters struct {
 	Condition []ImageIAMMemberConditionInitParameters `json:"condition,omitempty" tf:"condition,omitempty"`
 
-	// +crossplane:generate:reference:type=Image
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Image
 	Image *string `json:"image,omitempty" tf:"image,omitempty"`
 
-	// Reference to a Image to populate image.
+	// Reference to a Image in compute to populate image.
 	// +kubebuilder:validation:Optional
 	ImageRef *v1.Reference `json:"imageRef,omitempty" tf:"-"`
 
-	// Selector for a Image to populate image.
+	// Selector for a Image in compute to populate image.
 	// +kubebuilder:validation:Optional
 	ImageSelector *v1.Selector `json:"imageSelector,omitempty" tf:"-"`
 
@@ -83,15 +83,15 @@ type ImageIAMMemberParameters struct {
 	// +kubebuilder:validation:Optional
 	Condition []ImageIAMMemberConditionParameters `json:"condition,omitempty" tf:"condition,omitempty"`
 
-	// +crossplane:generate:reference:type=Image
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Image
 	// +kubebuilder:validation:Optional
 	Image *string `json:"image,omitempty" tf:"image,omitempty"`
 
-	// Reference to a Image to populate image.
+	// Reference to a Image in compute to populate image.
 	// +kubebuilder:validation:Optional
 	ImageRef *v1.Reference `json:"imageRef,omitempty" tf:"-"`
 
-	// Selector for a Image to populate image.
+	// Selector for a Image in compute to populate image.
 	// +kubebuilder:validation:Optional
 	ImageSelector *v1.Selector `json:"imageSelector,omitempty" tf:"-"`
 

--- a/apis/compute/v1beta1/zz_instance_types.go
+++ b/apis/compute/v1beta1/zz_instance_types.go
@@ -390,14 +390,14 @@ type InitializeParamsInitParameters struct {
 	// google_compute_image data source.
 	// For instance, the image centos-6-v20180104 includes its family name centos-6.
 	// These images can be referred by family name here.
-	// +crossplane:generate:reference:type=Image
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Image
 	Image *string `json:"image,omitempty" tf:"image,omitempty"`
 
-	// Reference to a Image to populate image.
+	// Reference to a Image in compute to populate image.
 	// +kubebuilder:validation:Optional
 	ImageRef *v1.Reference `json:"imageRef,omitempty" tf:"-"`
 
-	// Selector for a Image to populate image.
+	// Selector for a Image in compute to populate image.
 	// +kubebuilder:validation:Optional
 	ImageSelector *v1.Selector `json:"imageSelector,omitempty" tf:"-"`
 
@@ -504,15 +504,15 @@ type InitializeParamsParameters struct {
 	// google_compute_image data source.
 	// For instance, the image centos-6-v20180104 includes its family name centos-6.
 	// These images can be referred by family name here.
-	// +crossplane:generate:reference:type=Image
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Image
 	// +kubebuilder:validation:Optional
 	Image *string `json:"image,omitempty" tf:"image,omitempty"`
 
-	// Reference to a Image to populate image.
+	// Reference to a Image in compute to populate image.
 	// +kubebuilder:validation:Optional
 	ImageRef *v1.Reference `json:"imageRef,omitempty" tf:"-"`
 
-	// Selector for a Image to populate image.
+	// Selector for a Image in compute to populate image.
 	// +kubebuilder:validation:Optional
 	ImageSelector *v1.Selector `json:"imageSelector,omitempty" tf:"-"`
 
@@ -1162,7 +1162,7 @@ type NetworkInterfaceInitParameters struct {
 	// The name or self_link of the network to attach this interface to.
 	// Either network or subnetwork must be provided. If network isn't provided it will
 	// be inferred from the subnetwork.
-	// +crossplane:generate:reference:type=Network
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Network
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	Network *string `json:"network,omitempty" tf:"network,omitempty"`
 
@@ -1170,11 +1170,11 @@ type NetworkInterfaceInitParameters struct {
 	// empty, the address will be automatically assigned.
 	NetworkIP *string `json:"networkIp,omitempty" tf:"network_ip,omitempty"`
 
-	// Reference to a Network to populate network.
+	// Reference to a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkRef *v1.Reference `json:"networkRef,omitempty" tf:"-"`
 
-	// Selector for a Network to populate network.
+	// Selector for a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkSelector *v1.Selector `json:"networkSelector,omitempty" tf:"-"`
 
@@ -1194,7 +1194,7 @@ type NetworkInterfaceInitParameters struct {
 	// legacy mode, do not specify this field. If the
 	// network is in auto subnet mode, specifying the subnetwork is optional. If the network is
 	// in custom subnet mode, specifying the subnetwork is required.
-	// +crossplane:generate:reference:type=Subnetwork
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Subnetwork
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	Subnetwork *string `json:"subnetwork,omitempty" tf:"subnetwork,omitempty"`
 
@@ -1204,11 +1204,11 @@ type NetworkInterfaceInitParameters struct {
 	// field is not provided, the provider project is used.
 	SubnetworkProject *string `json:"subnetworkProject,omitempty" tf:"subnetwork_project,omitempty"`
 
-	// Reference to a Subnetwork to populate subnetwork.
+	// Reference to a Subnetwork in compute to populate subnetwork.
 	// +kubebuilder:validation:Optional
 	SubnetworkRef *v1.Reference `json:"subnetworkRef,omitempty" tf:"-"`
 
-	// Selector for a Subnetwork to populate subnetwork.
+	// Selector for a Subnetwork in compute to populate subnetwork.
 	// +kubebuilder:validation:Optional
 	SubnetworkSelector *v1.Selector `json:"subnetworkSelector,omitempty" tf:"-"`
 }
@@ -1309,7 +1309,7 @@ type NetworkInterfaceParameters struct {
 	// The name or self_link of the network to attach this interface to.
 	// Either network or subnetwork must be provided. If network isn't provided it will
 	// be inferred from the subnetwork.
-	// +crossplane:generate:reference:type=Network
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Network
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	// +kubebuilder:validation:Optional
 	Network *string `json:"network,omitempty" tf:"network,omitempty"`
@@ -1319,11 +1319,11 @@ type NetworkInterfaceParameters struct {
 	// +kubebuilder:validation:Optional
 	NetworkIP *string `json:"networkIp,omitempty" tf:"network_ip,omitempty"`
 
-	// Reference to a Network to populate network.
+	// Reference to a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkRef *v1.Reference `json:"networkRef,omitempty" tf:"-"`
 
-	// Selector for a Network to populate network.
+	// Selector for a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkSelector *v1.Selector `json:"networkSelector,omitempty" tf:"-"`
 
@@ -1346,7 +1346,7 @@ type NetworkInterfaceParameters struct {
 	// legacy mode, do not specify this field. If the
 	// network is in auto subnet mode, specifying the subnetwork is optional. If the network is
 	// in custom subnet mode, specifying the subnetwork is required.
-	// +crossplane:generate:reference:type=Subnetwork
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Subnetwork
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	// +kubebuilder:validation:Optional
 	Subnetwork *string `json:"subnetwork,omitempty" tf:"subnetwork,omitempty"`
@@ -1358,11 +1358,11 @@ type NetworkInterfaceParameters struct {
 	// +kubebuilder:validation:Optional
 	SubnetworkProject *string `json:"subnetworkProject,omitempty" tf:"subnetwork_project,omitempty"`
 
-	// Reference to a Subnetwork to populate subnetwork.
+	// Reference to a Subnetwork in compute to populate subnetwork.
 	// +kubebuilder:validation:Optional
 	SubnetworkRef *v1.Reference `json:"subnetworkRef,omitempty" tf:"-"`
 
-	// Selector for a Subnetwork to populate subnetwork.
+	// Selector for a Subnetwork in compute to populate subnetwork.
 	// +kubebuilder:validation:Optional
 	SubnetworkSelector *v1.Selector `json:"subnetworkSelector,omitempty" tf:"-"`
 }

--- a/apis/compute/v1beta1/zz_instancefromtemplate_types.go
+++ b/apis/compute/v1beta1/zz_instancefromtemplate_types.go
@@ -330,15 +330,15 @@ type InstanceFromTemplateInitParameters struct {
 	// Name or self link of an instance
 	// template to create the instance based on. It is recommended to reference
 	// instance templates through their unique id (self_link_unique attribute).
-	// +crossplane:generate:reference:type=InstanceTemplate
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.InstanceTemplate
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	SourceInstanceTemplate *string `json:"sourceInstanceTemplate,omitempty" tf:"source_instance_template,omitempty"`
 
-	// Reference to a InstanceTemplate to populate sourceInstanceTemplate.
+	// Reference to a InstanceTemplate in compute to populate sourceInstanceTemplate.
 	// +kubebuilder:validation:Optional
 	SourceInstanceTemplateRef *v1.Reference `json:"sourceInstanceTemplateRef,omitempty" tf:"-"`
 
-	// Selector for a InstanceTemplate to populate sourceInstanceTemplate.
+	// Selector for a InstanceTemplate in compute to populate sourceInstanceTemplate.
 	// +kubebuilder:validation:Optional
 	SourceInstanceTemplateSelector *v1.Selector `json:"sourceInstanceTemplateSelector,omitempty" tf:"-"`
 
@@ -361,16 +361,16 @@ type InstanceFromTemplateNetworkInterfaceInitParameters struct {
 
 	InternalIPv6PrefixLength *float64 `json:"internalIpv6PrefixLength,omitempty" tf:"internal_ipv6_prefix_length,omitempty"`
 
-	// +crossplane:generate:reference:type=Network
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Network
 	Network *string `json:"network,omitempty" tf:"network,omitempty"`
 
 	NetworkIP *string `json:"networkIp,omitempty" tf:"network_ip,omitempty"`
 
-	// Reference to a Network to populate network.
+	// Reference to a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkRef *v1.Reference `json:"networkRef,omitempty" tf:"-"`
 
-	// Selector for a Network to populate network.
+	// Selector for a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkSelector *v1.Selector `json:"networkSelector,omitempty" tf:"-"`
 
@@ -380,16 +380,16 @@ type InstanceFromTemplateNetworkInterfaceInitParameters struct {
 
 	StackType *string `json:"stackType,omitempty" tf:"stack_type,omitempty"`
 
-	// +crossplane:generate:reference:type=Subnetwork
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Subnetwork
 	Subnetwork *string `json:"subnetwork,omitempty" tf:"subnetwork,omitempty"`
 
 	SubnetworkProject *string `json:"subnetworkProject,omitempty" tf:"subnetwork_project,omitempty"`
 
-	// Reference to a Subnetwork to populate subnetwork.
+	// Reference to a Subnetwork in compute to populate subnetwork.
 	// +kubebuilder:validation:Optional
 	SubnetworkRef *v1.Reference `json:"subnetworkRef,omitempty" tf:"-"`
 
-	// Selector for a Subnetwork to populate subnetwork.
+	// Selector for a Subnetwork in compute to populate subnetwork.
 	// +kubebuilder:validation:Optional
 	SubnetworkSelector *v1.Selector `json:"subnetworkSelector,omitempty" tf:"-"`
 }
@@ -443,18 +443,18 @@ type InstanceFromTemplateNetworkInterfaceParameters struct {
 	// +kubebuilder:validation:Optional
 	InternalIPv6PrefixLength *float64 `json:"internalIpv6PrefixLength,omitempty" tf:"internal_ipv6_prefix_length,omitempty"`
 
-	// +crossplane:generate:reference:type=Network
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Network
 	// +kubebuilder:validation:Optional
 	Network *string `json:"network,omitempty" tf:"network,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	NetworkIP *string `json:"networkIp,omitempty" tf:"network_ip,omitempty"`
 
-	// Reference to a Network to populate network.
+	// Reference to a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkRef *v1.Reference `json:"networkRef,omitempty" tf:"-"`
 
-	// Selector for a Network to populate network.
+	// Selector for a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkSelector *v1.Selector `json:"networkSelector,omitempty" tf:"-"`
 
@@ -467,18 +467,18 @@ type InstanceFromTemplateNetworkInterfaceParameters struct {
 	// +kubebuilder:validation:Optional
 	StackType *string `json:"stackType,omitempty" tf:"stack_type,omitempty"`
 
-	// +crossplane:generate:reference:type=Subnetwork
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Subnetwork
 	// +kubebuilder:validation:Optional
 	Subnetwork *string `json:"subnetwork,omitempty" tf:"subnetwork,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	SubnetworkProject *string `json:"subnetworkProject,omitempty" tf:"subnetwork_project,omitempty"`
 
-	// Reference to a Subnetwork to populate subnetwork.
+	// Reference to a Subnetwork in compute to populate subnetwork.
 	// +kubebuilder:validation:Optional
 	SubnetworkRef *v1.Reference `json:"subnetworkRef,omitempty" tf:"-"`
 
-	// Selector for a Subnetwork to populate subnetwork.
+	// Selector for a Subnetwork in compute to populate subnetwork.
 	// +kubebuilder:validation:Optional
 	SubnetworkSelector *v1.Selector `json:"subnetworkSelector,omitempty" tf:"-"`
 }
@@ -690,16 +690,16 @@ type InstanceFromTemplateParameters struct {
 	// Name or self link of an instance
 	// template to create the instance based on. It is recommended to reference
 	// instance templates through their unique id (self_link_unique attribute).
-	// +crossplane:generate:reference:type=InstanceTemplate
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.InstanceTemplate
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	SourceInstanceTemplate *string `json:"sourceInstanceTemplate,omitempty" tf:"source_instance_template,omitempty"`
 
-	// Reference to a InstanceTemplate to populate sourceInstanceTemplate.
+	// Reference to a InstanceTemplate in compute to populate sourceInstanceTemplate.
 	// +kubebuilder:validation:Optional
 	SourceInstanceTemplateRef *v1.Reference `json:"sourceInstanceTemplateRef,omitempty" tf:"-"`
 
-	// Selector for a InstanceTemplate to populate sourceInstanceTemplate.
+	// Selector for a InstanceTemplate in compute to populate sourceInstanceTemplate.
 	// +kubebuilder:validation:Optional
 	SourceInstanceTemplateSelector *v1.Selector `json:"sourceInstanceTemplateSelector,omitempty" tf:"-"`
 

--- a/apis/compute/v1beta1/zz_instancegroup_types.go
+++ b/apis/compute/v1beta1/zz_instancegroup_types.go
@@ -32,15 +32,15 @@ type InstanceGroupInitParameters struct {
 	// this is different from the network where the instances are in, the creation
 	// fails. Defaults to the network where the instances are in (if neither
 	// network nor instances is specified, this field will be blank).
-	// +crossplane:generate:reference:type=Network
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Network
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	Network *string `json:"network,omitempty" tf:"network,omitempty"`
 
-	// Reference to a Network to populate network.
+	// Reference to a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkRef *v1.Reference `json:"networkRef,omitempty" tf:"-"`
 
-	// Selector for a Network to populate network.
+	// Selector for a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkSelector *v1.Selector `json:"networkSelector,omitempty" tf:"-"`
 
@@ -109,16 +109,16 @@ type InstanceGroupParameters struct {
 	// this is different from the network where the instances are in, the creation
 	// fails. Defaults to the network where the instances are in (if neither
 	// network nor instances is specified, this field will be blank).
-	// +crossplane:generate:reference:type=Network
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Network
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	// +kubebuilder:validation:Optional
 	Network *string `json:"network,omitempty" tf:"network,omitempty"`
 
-	// Reference to a Network to populate network.
+	// Reference to a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkRef *v1.Reference `json:"networkRef,omitempty" tf:"-"`
 
-	// Selector for a Network to populate network.
+	// Selector for a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkSelector *v1.Selector `json:"networkSelector,omitempty" tf:"-"`
 

--- a/apis/compute/v1beta1/zz_instancegroupmanager_types.go
+++ b/apis/compute/v1beta1/zz_instancegroupmanager_types.go
@@ -51,15 +51,15 @@ type AllInstancesConfigParameters struct {
 type AutoHealingPoliciesInitParameters struct {
 
 	// The health check resource that signals autohealing.
-	// +crossplane:generate:reference:type=HealthCheck
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.HealthCheck
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	HealthCheck *string `json:"healthCheck,omitempty" tf:"health_check,omitempty"`
 
-	// Reference to a HealthCheck to populate healthCheck.
+	// Reference to a HealthCheck in compute to populate healthCheck.
 	// +kubebuilder:validation:Optional
 	HealthCheckRef *v1.Reference `json:"healthCheckRef,omitempty" tf:"-"`
 
-	// Selector for a HealthCheck to populate healthCheck.
+	// Selector for a HealthCheck in compute to populate healthCheck.
 	// +kubebuilder:validation:Optional
 	HealthCheckSelector *v1.Selector `json:"healthCheckSelector,omitempty" tf:"-"`
 
@@ -81,16 +81,16 @@ type AutoHealingPoliciesObservation struct {
 type AutoHealingPoliciesParameters struct {
 
 	// The health check resource that signals autohealing.
-	// +crossplane:generate:reference:type=HealthCheck
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.HealthCheck
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	HealthCheck *string `json:"healthCheck,omitempty" tf:"health_check,omitempty"`
 
-	// Reference to a HealthCheck to populate healthCheck.
+	// Reference to a HealthCheck in compute to populate healthCheck.
 	// +kubebuilder:validation:Optional
 	HealthCheckRef *v1.Reference `json:"healthCheckRef,omitempty" tf:"-"`
 
-	// Selector for a HealthCheck to populate healthCheck.
+	// Selector for a HealthCheck in compute to populate healthCheck.
 	// +kubebuilder:validation:Optional
 	HealthCheckSelector *v1.Selector `json:"healthCheckSelector,omitempty" tf:"-"`
 
@@ -153,16 +153,16 @@ type InstanceGroupManagerInitParameters struct {
 	// The full URL of all target pools to which new
 	// instances in the group are added. Updating the target pools attribute does
 	// not affect existing instances.
-	// +crossplane:generate:reference:type=TargetPool
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.TargetPool
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	// +listType=set
 	TargetPools []*string `json:"targetPools,omitempty" tf:"target_pools,omitempty"`
 
-	// References to TargetPool to populate targetPools.
+	// References to TargetPool in compute to populate targetPools.
 	// +kubebuilder:validation:Optional
 	TargetPoolsRefs []v1.Reference `json:"targetPoolsRefs,omitempty" tf:"-"`
 
-	// Selector for a list of TargetPool to populate targetPools.
+	// Selector for a list of TargetPool in compute to populate targetPools.
 	// +kubebuilder:validation:Optional
 	TargetPoolsSelector *v1.Selector `json:"targetPoolsSelector,omitempty" tf:"-"`
 
@@ -388,17 +388,17 @@ type InstanceGroupManagerParameters struct {
 	// The full URL of all target pools to which new
 	// instances in the group are added. Updating the target pools attribute does
 	// not affect existing instances.
-	// +crossplane:generate:reference:type=TargetPool
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.TargetPool
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	// +kubebuilder:validation:Optional
 	// +listType=set
 	TargetPools []*string `json:"targetPools,omitempty" tf:"target_pools,omitempty"`
 
-	// References to TargetPool to populate targetPools.
+	// References to TargetPool in compute to populate targetPools.
 	// +kubebuilder:validation:Optional
 	TargetPoolsRefs []v1.Reference `json:"targetPoolsRefs,omitempty" tf:"-"`
 
-	// Selector for a list of TargetPool to populate targetPools.
+	// Selector for a list of TargetPool in compute to populate targetPools.
 	// +kubebuilder:validation:Optional
 	TargetPoolsSelector *v1.Selector `json:"targetPoolsSelector,omitempty" tf:"-"`
 
@@ -730,15 +730,15 @@ type UpdatePolicyParameters struct {
 type VersionInitParameters struct {
 
 	// - The full URL to an instance template from which all new instances of this version will be created. It is recommended to reference instance templates through their unique id (self_link_unique attribute).
-	// +crossplane:generate:reference:type=InstanceTemplate
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.InstanceTemplate
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	InstanceTemplate *string `json:"instanceTemplate,omitempty" tf:"instance_template,omitempty"`
 
-	// Reference to a InstanceTemplate to populate instanceTemplate.
+	// Reference to a InstanceTemplate in compute to populate instanceTemplate.
 	// +kubebuilder:validation:Optional
 	InstanceTemplateRef *v1.Reference `json:"instanceTemplateRef,omitempty" tf:"-"`
 
-	// Selector for a InstanceTemplate to populate instanceTemplate.
+	// Selector for a InstanceTemplate in compute to populate instanceTemplate.
 	// +kubebuilder:validation:Optional
 	InstanceTemplateSelector *v1.Selector `json:"instanceTemplateSelector,omitempty" tf:"-"`
 
@@ -764,16 +764,16 @@ type VersionObservation struct {
 type VersionParameters struct {
 
 	// - The full URL to an instance template from which all new instances of this version will be created. It is recommended to reference instance templates through their unique id (self_link_unique attribute).
-	// +crossplane:generate:reference:type=InstanceTemplate
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.InstanceTemplate
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	InstanceTemplate *string `json:"instanceTemplate,omitempty" tf:"instance_template,omitempty"`
 
-	// Reference to a InstanceTemplate to populate instanceTemplate.
+	// Reference to a InstanceTemplate in compute to populate instanceTemplate.
 	// +kubebuilder:validation:Optional
 	InstanceTemplateRef *v1.Reference `json:"instanceTemplateRef,omitempty" tf:"-"`
 
-	// Selector for a InstanceTemplate to populate instanceTemplate.
+	// Selector for a InstanceTemplate in compute to populate instanceTemplate.
 	// +kubebuilder:validation:Optional
 	InstanceTemplateSelector *v1.Selector `json:"instanceTemplateSelector,omitempty" tf:"-"`
 

--- a/apis/compute/v1beta1/zz_instanceiammember_types.go
+++ b/apis/compute/v1beta1/zz_instanceiammember_types.go
@@ -44,14 +44,14 @@ type InstanceIAMMemberConditionParameters struct {
 type InstanceIAMMemberInitParameters struct {
 	Condition []InstanceIAMMemberConditionInitParameters `json:"condition,omitempty" tf:"condition,omitempty"`
 
-	// +crossplane:generate:reference:type=Instance
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Instance
 	InstanceName *string `json:"instanceName,omitempty" tf:"instance_name,omitempty"`
 
-	// Reference to a Instance to populate instanceName.
+	// Reference to a Instance in compute to populate instanceName.
 	// +kubebuilder:validation:Optional
 	InstanceNameRef *v1.Reference `json:"instanceNameRef,omitempty" tf:"-"`
 
-	// Selector for a Instance to populate instanceName.
+	// Selector for a Instance in compute to populate instanceName.
 	// +kubebuilder:validation:Optional
 	InstanceNameSelector *v1.Selector `json:"instanceNameSelector,omitempty" tf:"-"`
 
@@ -87,15 +87,15 @@ type InstanceIAMMemberParameters struct {
 	// +kubebuilder:validation:Optional
 	Condition []InstanceIAMMemberConditionParameters `json:"condition,omitempty" tf:"condition,omitempty"`
 
-	// +crossplane:generate:reference:type=Instance
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Instance
 	// +kubebuilder:validation:Optional
 	InstanceName *string `json:"instanceName,omitempty" tf:"instance_name,omitempty"`
 
-	// Reference to a Instance to populate instanceName.
+	// Reference to a Instance in compute to populate instanceName.
 	// +kubebuilder:validation:Optional
 	InstanceNameRef *v1.Reference `json:"instanceNameRef,omitempty" tf:"-"`
 
-	// Selector for a Instance to populate instanceName.
+	// Selector for a Instance in compute to populate instanceName.
 	// +kubebuilder:validation:Optional
 	InstanceNameSelector *v1.Selector `json:"instanceNameSelector,omitempty" tf:"-"`
 

--- a/apis/compute/v1beta1/zz_instancetemplate_types.go
+++ b/apis/compute/v1beta1/zz_instancetemplate_types.go
@@ -755,18 +755,18 @@ type InstanceTemplateNetworkInterfaceInitParameters struct {
 	// The name or self_link of the network to attach this interface to.
 	// Use network attribute for Legacy or Auto subnetted networks and
 	// subnetwork for custom subnetted networks.
-	// +crossplane:generate:reference:type=Network
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Network
 	Network *string `json:"network,omitempty" tf:"network,omitempty"`
 
 	// The private IP address to assign to the instance. If
 	// empty, the address will be automatically assigned.
 	NetworkIP *string `json:"networkIp,omitempty" tf:"network_ip,omitempty"`
 
-	// Reference to a Network to populate network.
+	// Reference to a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkRef *v1.Reference `json:"networkRef,omitempty" tf:"-"`
 
-	// Selector for a Network to populate network.
+	// Selector for a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkSelector *v1.Selector `json:"networkSelector,omitempty" tf:"-"`
 
@@ -782,18 +782,18 @@ type InstanceTemplateNetworkInterfaceInitParameters struct {
 	// the name of the subnetwork to attach this interface
 	// to. The subnetwork must exist in the same region this instance will be
 	// created in. Either network or subnetwork must be provided.
-	// +crossplane:generate:reference:type=Subnetwork
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Subnetwork
 	Subnetwork *string `json:"subnetwork,omitempty" tf:"subnetwork,omitempty"`
 
 	// The ID of the project in which the subnetwork belongs.
 	// If it is not provided, the provider project is used.
 	SubnetworkProject *string `json:"subnetworkProject,omitempty" tf:"subnetwork_project,omitempty"`
 
-	// Reference to a Subnetwork to populate subnetwork.
+	// Reference to a Subnetwork in compute to populate subnetwork.
 	// +kubebuilder:validation:Optional
 	SubnetworkRef *v1.Reference `json:"subnetworkRef,omitempty" tf:"-"`
 
-	// Selector for a Subnetwork to populate subnetwork.
+	// Selector for a Subnetwork in compute to populate subnetwork.
 	// +kubebuilder:validation:Optional
 	SubnetworkSelector *v1.Selector `json:"subnetworkSelector,omitempty" tf:"-"`
 }
@@ -881,7 +881,7 @@ type InstanceTemplateNetworkInterfaceParameters struct {
 	// The name or self_link of the network to attach this interface to.
 	// Use network attribute for Legacy or Auto subnetted networks and
 	// subnetwork for custom subnetted networks.
-	// +crossplane:generate:reference:type=Network
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Network
 	// +kubebuilder:validation:Optional
 	Network *string `json:"network,omitempty" tf:"network,omitempty"`
 
@@ -890,11 +890,11 @@ type InstanceTemplateNetworkInterfaceParameters struct {
 	// +kubebuilder:validation:Optional
 	NetworkIP *string `json:"networkIp,omitempty" tf:"network_ip,omitempty"`
 
-	// Reference to a Network to populate network.
+	// Reference to a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkRef *v1.Reference `json:"networkRef,omitempty" tf:"-"`
 
-	// Selector for a Network to populate network.
+	// Selector for a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkSelector *v1.Selector `json:"networkSelector,omitempty" tf:"-"`
 
@@ -913,7 +913,7 @@ type InstanceTemplateNetworkInterfaceParameters struct {
 	// the name of the subnetwork to attach this interface
 	// to. The subnetwork must exist in the same region this instance will be
 	// created in. Either network or subnetwork must be provided.
-	// +crossplane:generate:reference:type=Subnetwork
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Subnetwork
 	// +kubebuilder:validation:Optional
 	Subnetwork *string `json:"subnetwork,omitempty" tf:"subnetwork,omitempty"`
 
@@ -922,11 +922,11 @@ type InstanceTemplateNetworkInterfaceParameters struct {
 	// +kubebuilder:validation:Optional
 	SubnetworkProject *string `json:"subnetworkProject,omitempty" tf:"subnetwork_project,omitempty"`
 
-	// Reference to a Subnetwork to populate subnetwork.
+	// Reference to a Subnetwork in compute to populate subnetwork.
 	// +kubebuilder:validation:Optional
 	SubnetworkRef *v1.Reference `json:"subnetworkRef,omitempty" tf:"-"`
 
-	// Selector for a Subnetwork to populate subnetwork.
+	// Selector for a Subnetwork in compute to populate subnetwork.
 	// +kubebuilder:validation:Optional
 	SubnetworkSelector *v1.Selector `json:"subnetworkSelector,omitempty" tf:"-"`
 }

--- a/apis/compute/v1beta1/zz_interconnectattachment_types.go
+++ b/apis/compute/v1beta1/zz_interconnectattachment_types.go
@@ -86,15 +86,15 @@ type InterconnectAttachmentInitParameters struct {
 	// the same region as this InterconnectAttachment. The InterconnectAttachment will
 	// automatically connect the Interconnect to the network & region within which the
 	// Cloud Router is configured.
-	// +crossplane:generate:reference:type=Router
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Router
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	Router *string `json:"router,omitempty" tf:"router,omitempty"`
 
-	// Reference to a Router to populate router.
+	// Reference to a Router in compute to populate router.
 	// +kubebuilder:validation:Optional
 	RouterRef *v1.Reference `json:"routerRef,omitempty" tf:"-"`
 
-	// Selector for a Router to populate router.
+	// Selector for a Router in compute to populate router.
 	// +kubebuilder:validation:Optional
 	RouterSelector *v1.Selector `json:"routerSelector,omitempty" tf:"-"`
 
@@ -336,16 +336,16 @@ type InterconnectAttachmentParameters struct {
 	// the same region as this InterconnectAttachment. The InterconnectAttachment will
 	// automatically connect the Interconnect to the network & region within which the
 	// Cloud Router is configured.
-	// +crossplane:generate:reference:type=Router
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Router
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	// +kubebuilder:validation:Optional
 	Router *string `json:"router,omitempty" tf:"router,omitempty"`
 
-	// Reference to a Router to populate router.
+	// Reference to a Router in compute to populate router.
 	// +kubebuilder:validation:Optional
 	RouterRef *v1.Reference `json:"routerRef,omitempty" tf:"-"`
 
-	// Selector for a Router to populate router.
+	// Selector for a Router in compute to populate router.
 	// +kubebuilder:validation:Optional
 	RouterSelector *v1.Selector `json:"routerSelector,omitempty" tf:"-"`
 

--- a/apis/compute/v1beta1/zz_networkendpointgroup_types.go
+++ b/apis/compute/v1beta1/zz_networkendpointgroup_types.go
@@ -25,7 +25,7 @@ type NetworkEndpointGroupInitParameters struct {
 
 	// The network to which all network endpoints in the NEG belong.
 	// Uses "default" project network if unspecified.
-	// +crossplane:generate:reference:type=Network
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Network
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	Network *string `json:"network,omitempty" tf:"network,omitempty"`
 
@@ -41,11 +41,11 @@ type NetworkEndpointGroupInitParameters struct {
 	// Possible values are: GCE_VM_IP, GCE_VM_IP_PORT, NON_GCP_PRIVATE_IP_PORT, INTERNET_IP_PORT, INTERNET_FQDN_PORT, SERVERLESS, PRIVATE_SERVICE_CONNECT.
 	NetworkEndpointType *string `json:"networkEndpointType,omitempty" tf:"network_endpoint_type,omitempty"`
 
-	// Reference to a Network to populate network.
+	// Reference to a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkRef *v1.Reference `json:"networkRef,omitempty" tf:"-"`
 
-	// Selector for a Network to populate network.
+	// Selector for a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkSelector *v1.Selector `json:"networkSelector,omitempty" tf:"-"`
 
@@ -54,15 +54,15 @@ type NetworkEndpointGroupInitParameters struct {
 	Project *string `json:"project,omitempty" tf:"project,omitempty"`
 
 	// Optional subnetwork to which all network endpoints in the NEG belong.
-	// +crossplane:generate:reference:type=Subnetwork
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Subnetwork
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	Subnetwork *string `json:"subnetwork,omitempty" tf:"subnetwork,omitempty"`
 
-	// Reference to a Subnetwork to populate subnetwork.
+	// Reference to a Subnetwork in compute to populate subnetwork.
 	// +kubebuilder:validation:Optional
 	SubnetworkRef *v1.Reference `json:"subnetworkRef,omitempty" tf:"-"`
 
-	// Selector for a Subnetwork to populate subnetwork.
+	// Selector for a Subnetwork in compute to populate subnetwork.
 	// +kubebuilder:validation:Optional
 	SubnetworkSelector *v1.Selector `json:"subnetworkSelector,omitempty" tf:"-"`
 }
@@ -127,7 +127,7 @@ type NetworkEndpointGroupParameters struct {
 
 	// The network to which all network endpoints in the NEG belong.
 	// Uses "default" project network if unspecified.
-	// +crossplane:generate:reference:type=Network
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Network
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	Network *string `json:"network,omitempty" tf:"network,omitempty"`
@@ -145,11 +145,11 @@ type NetworkEndpointGroupParameters struct {
 	// +kubebuilder:validation:Optional
 	NetworkEndpointType *string `json:"networkEndpointType,omitempty" tf:"network_endpoint_type,omitempty"`
 
-	// Reference to a Network to populate network.
+	// Reference to a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkRef *v1.Reference `json:"networkRef,omitempty" tf:"-"`
 
-	// Selector for a Network to populate network.
+	// Selector for a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkSelector *v1.Selector `json:"networkSelector,omitempty" tf:"-"`
 
@@ -159,16 +159,16 @@ type NetworkEndpointGroupParameters struct {
 	Project *string `json:"project,omitempty" tf:"project,omitempty"`
 
 	// Optional subnetwork to which all network endpoints in the NEG belong.
-	// +crossplane:generate:reference:type=Subnetwork
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Subnetwork
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	Subnetwork *string `json:"subnetwork,omitempty" tf:"subnetwork,omitempty"`
 
-	// Reference to a Subnetwork to populate subnetwork.
+	// Reference to a Subnetwork in compute to populate subnetwork.
 	// +kubebuilder:validation:Optional
 	SubnetworkRef *v1.Reference `json:"subnetworkRef,omitempty" tf:"-"`
 
-	// Selector for a Subnetwork to populate subnetwork.
+	// Selector for a Subnetwork in compute to populate subnetwork.
 	// +kubebuilder:validation:Optional
 	SubnetworkSelector *v1.Selector `json:"subnetworkSelector,omitempty" tf:"-"`
 

--- a/apis/compute/v1beta1/zz_regionbackendservice_types.go
+++ b/apis/compute/v1beta1/zz_regionbackendservice_types.go
@@ -329,15 +329,15 @@ type RegionBackendServiceBackendInitParameters struct {
 	// Note that you must specify an Instance Group or Network Endpoint
 	// Group resource using the fully-qualified URL, rather than a
 	// partial URL.
-	// +crossplane:generate:reference:type=RegionInstanceGroupManager
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.RegionInstanceGroupManager
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/compute.InstanceGroupExtractor()
 	Group *string `json:"group,omitempty" tf:"group,omitempty"`
 
-	// Reference to a RegionInstanceGroupManager to populate group.
+	// Reference to a RegionInstanceGroupManager in compute to populate group.
 	// +kubebuilder:validation:Optional
 	GroupRef *v1.Reference `json:"groupRef,omitempty" tf:"-"`
 
-	// Selector for a RegionInstanceGroupManager to populate group.
+	// Selector for a RegionInstanceGroupManager in compute to populate group.
 	// +kubebuilder:validation:Optional
 	GroupSelector *v1.Selector `json:"groupSelector,omitempty" tf:"-"`
 
@@ -541,16 +541,16 @@ type RegionBackendServiceBackendParameters struct {
 	// Note that you must specify an Instance Group or Network Endpoint
 	// Group resource using the fully-qualified URL, rather than a
 	// partial URL.
-	// +crossplane:generate:reference:type=RegionInstanceGroupManager
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.RegionInstanceGroupManager
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/compute.InstanceGroupExtractor()
 	// +kubebuilder:validation:Optional
 	Group *string `json:"group,omitempty" tf:"group,omitempty"`
 
-	// Reference to a RegionInstanceGroupManager to populate group.
+	// Reference to a RegionInstanceGroupManager in compute to populate group.
 	// +kubebuilder:validation:Optional
 	GroupRef *v1.Reference `json:"groupRef,omitempty" tf:"-"`
 
-	// Selector for a RegionInstanceGroupManager to populate group.
+	// Selector for a RegionInstanceGroupManager in compute to populate group.
 	// +kubebuilder:validation:Optional
 	GroupSelector *v1.Selector `json:"groupSelector,omitempty" tf:"-"`
 
@@ -1116,16 +1116,16 @@ type RegionBackendServiceInitParameters struct {
 	// check can be specified.
 	// A health check must be specified unless the backend service uses an internet
 	// or serverless NEG as a backend.
-	// +crossplane:generate:reference:type=RegionHealthCheck
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.RegionHealthCheck
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	// +listType=set
 	HealthChecks []*string `json:"healthChecks,omitempty" tf:"health_checks,omitempty"`
 
-	// References to RegionHealthCheck to populate healthChecks.
+	// References to RegionHealthCheck in compute to populate healthChecks.
 	// +kubebuilder:validation:Optional
 	HealthChecksRefs []v1.Reference `json:"healthChecksRefs,omitempty" tf:"-"`
 
-	// Selector for a list of RegionHealthCheck to populate healthChecks.
+	// Selector for a list of RegionHealthCheck in compute to populate healthChecks.
 	// +kubebuilder:validation:Optional
 	HealthChecksSelector *v1.Selector `json:"healthChecksSelector,omitempty" tf:"-"`
 
@@ -1605,17 +1605,17 @@ type RegionBackendServiceParameters struct {
 	// check can be specified.
 	// A health check must be specified unless the backend service uses an internet
 	// or serverless NEG as a backend.
-	// +crossplane:generate:reference:type=RegionHealthCheck
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.RegionHealthCheck
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	// +kubebuilder:validation:Optional
 	// +listType=set
 	HealthChecks []*string `json:"healthChecks,omitempty" tf:"health_checks,omitempty"`
 
-	// References to RegionHealthCheck to populate healthChecks.
+	// References to RegionHealthCheck in compute to populate healthChecks.
 	// +kubebuilder:validation:Optional
 	HealthChecksRefs []v1.Reference `json:"healthChecksRefs,omitempty" tf:"-"`
 
-	// Selector for a list of RegionHealthCheck to populate healthChecks.
+	// Selector for a list of RegionHealthCheck in compute to populate healthChecks.
 	// +kubebuilder:validation:Optional
 	HealthChecksSelector *v1.Selector `json:"healthChecksSelector,omitempty" tf:"-"`
 

--- a/apis/compute/v1beta1/zz_regiondiskiammember_types.go
+++ b/apis/compute/v1beta1/zz_regiondiskiammember_types.go
@@ -46,14 +46,14 @@ type RegionDiskIAMMemberInitParameters struct {
 
 	Member *string `json:"member,omitempty" tf:"member,omitempty"`
 
-	// +crossplane:generate:reference:type=RegionDisk
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.RegionDisk
 	Name *string `json:"name,omitempty" tf:"name,omitempty"`
 
-	// Reference to a RegionDisk to populate name.
+	// Reference to a RegionDisk in compute to populate name.
 	// +kubebuilder:validation:Optional
 	NameRef *v1.Reference `json:"nameRef,omitempty" tf:"-"`
 
-	// Selector for a RegionDisk to populate name.
+	// Selector for a RegionDisk in compute to populate name.
 	// +kubebuilder:validation:Optional
 	NameSelector *v1.Selector `json:"nameSelector,omitempty" tf:"-"`
 
@@ -90,15 +90,15 @@ type RegionDiskIAMMemberParameters struct {
 	// +kubebuilder:validation:Optional
 	Member *string `json:"member,omitempty" tf:"member,omitempty"`
 
-	// +crossplane:generate:reference:type=RegionDisk
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.RegionDisk
 	// +kubebuilder:validation:Optional
 	Name *string `json:"name,omitempty" tf:"name,omitempty"`
 
-	// Reference to a RegionDisk to populate name.
+	// Reference to a RegionDisk in compute to populate name.
 	// +kubebuilder:validation:Optional
 	NameRef *v1.Reference `json:"nameRef,omitempty" tf:"-"`
 
-	// Selector for a RegionDisk to populate name.
+	// Selector for a RegionDisk in compute to populate name.
 	// +kubebuilder:validation:Optional
 	NameSelector *v1.Selector `json:"nameSelector,omitempty" tf:"-"`
 

--- a/apis/compute/v1beta1/zz_regioninstancegroupmanager_types.go
+++ b/apis/compute/v1beta1/zz_regioninstancegroupmanager_types.go
@@ -51,15 +51,15 @@ type RegionInstanceGroupManagerAllInstancesConfigParameters struct {
 type RegionInstanceGroupManagerAutoHealingPoliciesInitParameters struct {
 
 	// The health check resource that signals autohealing.
-	// +crossplane:generate:reference:type=HealthCheck
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.HealthCheck
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	HealthCheck *string `json:"healthCheck,omitempty" tf:"health_check,omitempty"`
 
-	// Reference to a HealthCheck to populate healthCheck.
+	// Reference to a HealthCheck in compute to populate healthCheck.
 	// +kubebuilder:validation:Optional
 	HealthCheckRef *v1.Reference `json:"healthCheckRef,omitempty" tf:"-"`
 
-	// Selector for a HealthCheck to populate healthCheck.
+	// Selector for a HealthCheck in compute to populate healthCheck.
 	// +kubebuilder:validation:Optional
 	HealthCheckSelector *v1.Selector `json:"healthCheckSelector,omitempty" tf:"-"`
 
@@ -81,16 +81,16 @@ type RegionInstanceGroupManagerAutoHealingPoliciesObservation struct {
 type RegionInstanceGroupManagerAutoHealingPoliciesParameters struct {
 
 	// The health check resource that signals autohealing.
-	// +crossplane:generate:reference:type=HealthCheck
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.HealthCheck
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	HealthCheck *string `json:"healthCheck,omitempty" tf:"health_check,omitempty"`
 
-	// Reference to a HealthCheck to populate healthCheck.
+	// Reference to a HealthCheck in compute to populate healthCheck.
 	// +kubebuilder:validation:Optional
 	HealthCheckRef *v1.Reference `json:"healthCheckRef,omitempty" tf:"-"`
 
-	// Selector for a HealthCheck to populate healthCheck.
+	// Selector for a HealthCheck in compute to populate healthCheck.
 	// +kubebuilder:validation:Optional
 	HealthCheckSelector *v1.Selector `json:"healthCheckSelector,omitempty" tf:"-"`
 
@@ -170,16 +170,16 @@ type RegionInstanceGroupManagerInitParameters struct {
 	// The full URL of all target pools to which new
 	// instances in the group are added. Updating the target pools attribute does
 	// not affect existing instances.
-	// +crossplane:generate:reference:type=TargetPool
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.TargetPool
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	// +listType=set
 	TargetPools []*string `json:"targetPools,omitempty" tf:"target_pools,omitempty"`
 
-	// References to TargetPool to populate targetPools.
+	// References to TargetPool in compute to populate targetPools.
 	// +kubebuilder:validation:Optional
 	TargetPoolsRefs []v1.Reference `json:"targetPoolsRefs,omitempty" tf:"-"`
 
-	// Selector for a list of TargetPool to populate targetPools.
+	// Selector for a list of TargetPool in compute to populate targetPools.
 	// +kubebuilder:validation:Optional
 	TargetPoolsSelector *v1.Selector `json:"targetPoolsSelector,omitempty" tf:"-"`
 
@@ -455,17 +455,17 @@ type RegionInstanceGroupManagerParameters struct {
 	// The full URL of all target pools to which new
 	// instances in the group are added. Updating the target pools attribute does
 	// not affect existing instances.
-	// +crossplane:generate:reference:type=TargetPool
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.TargetPool
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	// +kubebuilder:validation:Optional
 	// +listType=set
 	TargetPools []*string `json:"targetPools,omitempty" tf:"target_pools,omitempty"`
 
-	// References to TargetPool to populate targetPools.
+	// References to TargetPool in compute to populate targetPools.
 	// +kubebuilder:validation:Optional
 	TargetPoolsRefs []v1.Reference `json:"targetPoolsRefs,omitempty" tf:"-"`
 
-	// Selector for a list of TargetPool to populate targetPools.
+	// Selector for a list of TargetPool in compute to populate targetPools.
 	// +kubebuilder:validation:Optional
 	TargetPoolsSelector *v1.Selector `json:"targetPoolsSelector,omitempty" tf:"-"`
 
@@ -721,15 +721,15 @@ type RegionInstanceGroupManagerUpdatePolicyParameters struct {
 type RegionInstanceGroupManagerVersionInitParameters struct {
 
 	// - The full URL to an instance template from which all new instances of this version will be created.
-	// +crossplane:generate:reference:type=InstanceTemplate
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.InstanceTemplate
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	InstanceTemplate *string `json:"instanceTemplate,omitempty" tf:"instance_template,omitempty"`
 
-	// Reference to a InstanceTemplate to populate instanceTemplate.
+	// Reference to a InstanceTemplate in compute to populate instanceTemplate.
 	// +kubebuilder:validation:Optional
 	InstanceTemplateRef *v1.Reference `json:"instanceTemplateRef,omitempty" tf:"-"`
 
-	// Selector for a InstanceTemplate to populate instanceTemplate.
+	// Selector for a InstanceTemplate in compute to populate instanceTemplate.
 	// +kubebuilder:validation:Optional
 	InstanceTemplateSelector *v1.Selector `json:"instanceTemplateSelector,omitempty" tf:"-"`
 
@@ -755,16 +755,16 @@ type RegionInstanceGroupManagerVersionObservation struct {
 type RegionInstanceGroupManagerVersionParameters struct {
 
 	// - The full URL to an instance template from which all new instances of this version will be created.
-	// +crossplane:generate:reference:type=InstanceTemplate
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.InstanceTemplate
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	InstanceTemplate *string `json:"instanceTemplate,omitempty" tf:"instance_template,omitempty"`
 
-	// Reference to a InstanceTemplate to populate instanceTemplate.
+	// Reference to a InstanceTemplate in compute to populate instanceTemplate.
 	// +kubebuilder:validation:Optional
 	InstanceTemplateRef *v1.Reference `json:"instanceTemplateRef,omitempty" tf:"-"`
 
-	// Selector for a InstanceTemplate to populate instanceTemplate.
+	// Selector for a InstanceTemplate in compute to populate instanceTemplate.
 	// +kubebuilder:validation:Optional
 	InstanceTemplateSelector *v1.Selector `json:"instanceTemplateSelector,omitempty" tf:"-"`
 

--- a/apis/compute/v1beta1/zz_regiontargethttpproxy_types.go
+++ b/apis/compute/v1beta1/zz_regiontargethttpproxy_types.go
@@ -24,15 +24,15 @@ type RegionTargetHTTPProxyInitParameters struct {
 
 	// A reference to the RegionUrlMap resource that defines the mapping from URL
 	// to the BackendService.
-	// +crossplane:generate:reference:type=RegionURLMap
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.RegionURLMap
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	URLMap *string `json:"urlMap,omitempty" tf:"url_map,omitempty"`
 
-	// Reference to a RegionURLMap to populate urlMap.
+	// Reference to a RegionURLMap in compute to populate urlMap.
 	// +kubebuilder:validation:Optional
 	URLMapRef *v1.Reference `json:"urlMapRef,omitempty" tf:"-"`
 
-	// Selector for a RegionURLMap to populate urlMap.
+	// Selector for a RegionURLMap in compute to populate urlMap.
 	// +kubebuilder:validation:Optional
 	URLMapSelector *v1.Selector `json:"urlMapSelector,omitempty" tf:"-"`
 }
@@ -85,16 +85,16 @@ type RegionTargetHTTPProxyParameters struct {
 
 	// A reference to the RegionUrlMap resource that defines the mapping from URL
 	// to the BackendService.
-	// +crossplane:generate:reference:type=RegionURLMap
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.RegionURLMap
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	// +kubebuilder:validation:Optional
 	URLMap *string `json:"urlMap,omitempty" tf:"url_map,omitempty"`
 
-	// Reference to a RegionURLMap to populate urlMap.
+	// Reference to a RegionURLMap in compute to populate urlMap.
 	// +kubebuilder:validation:Optional
 	URLMapRef *v1.Reference `json:"urlMapRef,omitempty" tf:"-"`
 
-	// Selector for a RegionURLMap to populate urlMap.
+	// Selector for a RegionURLMap in compute to populate urlMap.
 	// +kubebuilder:validation:Optional
 	URLMapSelector *v1.Selector `json:"urlMapSelector,omitempty" tf:"-"`
 }

--- a/apis/compute/v1beta1/zz_regiontargethttpsproxy_types.go
+++ b/apis/compute/v1beta1/zz_regiontargethttpsproxy_types.go
@@ -31,14 +31,14 @@ type RegionTargetHTTPSProxyInitParameters struct {
 	// URLs to SslCertificate resources that are used to authenticate connections between users and the load balancer.
 	// At least one SSL certificate must be specified. Currently, you may specify up to 15 SSL certificates.
 	// sslCertificates do not apply when the load balancing scheme is set to INTERNAL_SELF_MANAGED.
-	// +crossplane:generate:reference:type=RegionSSLCertificate
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.RegionSSLCertificate
 	SSLCertificates []*string `json:"sslCertificates,omitempty" tf:"ssl_certificates,omitempty"`
 
-	// References to RegionSSLCertificate to populate sslCertificates.
+	// References to RegionSSLCertificate in compute to populate sslCertificates.
 	// +kubebuilder:validation:Optional
 	SSLCertificatesRefs []v1.Reference `json:"sslCertificatesRefs,omitempty" tf:"-"`
 
-	// Selector for a list of RegionSSLCertificate to populate sslCertificates.
+	// Selector for a list of RegionSSLCertificate in compute to populate sslCertificates.
 	// +kubebuilder:validation:Optional
 	SSLCertificatesSelector *v1.Selector `json:"sslCertificatesSelector,omitempty" tf:"-"`
 
@@ -134,15 +134,15 @@ type RegionTargetHTTPSProxyParameters struct {
 	// URLs to SslCertificate resources that are used to authenticate connections between users and the load balancer.
 	// At least one SSL certificate must be specified. Currently, you may specify up to 15 SSL certificates.
 	// sslCertificates do not apply when the load balancing scheme is set to INTERNAL_SELF_MANAGED.
-	// +crossplane:generate:reference:type=RegionSSLCertificate
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.RegionSSLCertificate
 	// +kubebuilder:validation:Optional
 	SSLCertificates []*string `json:"sslCertificates,omitempty" tf:"ssl_certificates,omitempty"`
 
-	// References to RegionSSLCertificate to populate sslCertificates.
+	// References to RegionSSLCertificate in compute to populate sslCertificates.
 	// +kubebuilder:validation:Optional
 	SSLCertificatesRefs []v1.Reference `json:"sslCertificatesRefs,omitempty" tf:"-"`
 
-	// Selector for a list of RegionSSLCertificate to populate sslCertificates.
+	// Selector for a list of RegionSSLCertificate in compute to populate sslCertificates.
 	// +kubebuilder:validation:Optional
 	SSLCertificatesSelector *v1.Selector `json:"sslCertificatesSelector,omitempty" tf:"-"`
 

--- a/apis/compute/v1beta1/zz_route_types.go
+++ b/apis/compute/v1beta1/zz_route_types.go
@@ -69,14 +69,14 @@ type RouteInitParameters struct {
 	NextHopInstanceZone *string `json:"nextHopInstanceZone,omitempty" tf:"next_hop_instance_zone,omitempty"`
 
 	// URL to a VpnTunnel that should handle matching packets.
-	// +crossplane:generate:reference:type=VPNTunnel
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.VPNTunnel
 	NextHopVPNTunnel *string `json:"nextHopVpnTunnel,omitempty" tf:"next_hop_vpn_tunnel,omitempty"`
 
-	// Reference to a VPNTunnel to populate nextHopVpnTunnel.
+	// Reference to a VPNTunnel in compute to populate nextHopVpnTunnel.
 	// +kubebuilder:validation:Optional
 	NextHopVPNTunnelRef *v1.Reference `json:"nextHopVpnTunnelRef,omitempty" tf:"-"`
 
-	// Selector for a VPNTunnel to populate nextHopVpnTunnel.
+	// Selector for a VPNTunnel in compute to populate nextHopVpnTunnel.
 	// +kubebuilder:validation:Optional
 	NextHopVPNTunnelSelector *v1.Selector `json:"nextHopVpnTunnelSelector,omitempty" tf:"-"`
 
@@ -224,15 +224,15 @@ type RouteParameters struct {
 	NextHopInstanceZone *string `json:"nextHopInstanceZone,omitempty" tf:"next_hop_instance_zone,omitempty"`
 
 	// URL to a VpnTunnel that should handle matching packets.
-	// +crossplane:generate:reference:type=VPNTunnel
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.VPNTunnel
 	// +kubebuilder:validation:Optional
 	NextHopVPNTunnel *string `json:"nextHopVpnTunnel,omitempty" tf:"next_hop_vpn_tunnel,omitempty"`
 
-	// Reference to a VPNTunnel to populate nextHopVpnTunnel.
+	// Reference to a VPNTunnel in compute to populate nextHopVpnTunnel.
 	// +kubebuilder:validation:Optional
 	NextHopVPNTunnelRef *v1.Reference `json:"nextHopVpnTunnelRef,omitempty" tf:"-"`
 
-	// Selector for a VPNTunnel to populate nextHopVpnTunnel.
+	// Selector for a VPNTunnel in compute to populate nextHopVpnTunnel.
 	// +kubebuilder:validation:Optional
 	NextHopVPNTunnelSelector *v1.Selector `json:"nextHopVpnTunnelSelector,omitempty" tf:"-"`
 

--- a/apis/compute/v1beta1/zz_router_types.go
+++ b/apis/compute/v1beta1/zz_router_types.go
@@ -187,15 +187,15 @@ type RouterInitParameters struct {
 	EncryptedInterconnectRouter *bool `json:"encryptedInterconnectRouter,omitempty" tf:"encrypted_interconnect_router,omitempty"`
 
 	// A reference to the network to which this router belongs.
-	// +crossplane:generate:reference:type=Network
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Network
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	Network *string `json:"network,omitempty" tf:"network,omitempty"`
 
-	// Reference to a Network to populate network.
+	// Reference to a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkRef *v1.Reference `json:"networkRef,omitempty" tf:"-"`
 
-	// Selector for a Network to populate network.
+	// Selector for a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkSelector *v1.Selector `json:"networkSelector,omitempty" tf:"-"`
 
@@ -254,16 +254,16 @@ type RouterParameters struct {
 	EncryptedInterconnectRouter *bool `json:"encryptedInterconnectRouter,omitempty" tf:"encrypted_interconnect_router,omitempty"`
 
 	// A reference to the network to which this router belongs.
-	// +crossplane:generate:reference:type=Network
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Network
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	// +kubebuilder:validation:Optional
 	Network *string `json:"network,omitempty" tf:"network,omitempty"`
 
-	// Reference to a Network to populate network.
+	// Reference to a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkRef *v1.Reference `json:"networkRef,omitempty" tf:"-"`
 
-	// Selector for a Network to populate network.
+	// Selector for a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkSelector *v1.Selector `json:"networkSelector,omitempty" tf:"-"`
 

--- a/apis/compute/v1beta1/zz_routerinterface_types.go
+++ b/apis/compute/v1beta1/zz_routerinterface_types.go
@@ -46,14 +46,14 @@ type RouterInterfaceInitParameters struct {
 
 	// The name of the router this interface will be attached to.
 	// Changing this forces a new interface to be created.
-	// +crossplane:generate:reference:type=Router
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Router
 	Router *string `json:"router,omitempty" tf:"router,omitempty"`
 
-	// Reference to a Router to populate router.
+	// Reference to a Router in compute to populate router.
 	// +kubebuilder:validation:Optional
 	RouterRef *v1.Reference `json:"routerRef,omitempty" tf:"-"`
 
-	// Selector for a Router to populate router.
+	// Selector for a Router in compute to populate router.
 	// +kubebuilder:validation:Optional
 	RouterSelector *v1.Selector `json:"routerSelector,omitempty" tf:"-"`
 
@@ -64,14 +64,14 @@ type RouterInterfaceInitParameters struct {
 	// The name or resource link to the VPN tunnel this
 	// interface will be linked to. Changing this forces a new interface to be created. Only
 	// one of vpn_tunnel, interconnect_attachment or subnetwork can be specified.
-	// +crossplane:generate:reference:type=VPNTunnel
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.VPNTunnel
 	VPNTunnel *string `json:"vpnTunnel,omitempty" tf:"vpn_tunnel,omitempty"`
 
-	// Reference to a VPNTunnel to populate vpnTunnel.
+	// Reference to a VPNTunnel in compute to populate vpnTunnel.
 	// +kubebuilder:validation:Optional
 	VPNTunnelRef *v1.Reference `json:"vpnTunnelRef,omitempty" tf:"-"`
 
-	// Selector for a VPNTunnel to populate vpnTunnel.
+	// Selector for a VPNTunnel in compute to populate vpnTunnel.
 	// +kubebuilder:validation:Optional
 	VPNTunnelSelector *v1.Selector `json:"vpnTunnelSelector,omitempty" tf:"-"`
 }
@@ -164,15 +164,15 @@ type RouterInterfaceParameters struct {
 
 	// The name of the router this interface will be attached to.
 	// Changing this forces a new interface to be created.
-	// +crossplane:generate:reference:type=Router
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Router
 	// +kubebuilder:validation:Optional
 	Router *string `json:"router,omitempty" tf:"router,omitempty"`
 
-	// Reference to a Router to populate router.
+	// Reference to a Router in compute to populate router.
 	// +kubebuilder:validation:Optional
 	RouterRef *v1.Reference `json:"routerRef,omitempty" tf:"-"`
 
-	// Selector for a Router to populate router.
+	// Selector for a Router in compute to populate router.
 	// +kubebuilder:validation:Optional
 	RouterSelector *v1.Selector `json:"routerSelector,omitempty" tf:"-"`
 
@@ -184,15 +184,15 @@ type RouterInterfaceParameters struct {
 	// The name or resource link to the VPN tunnel this
 	// interface will be linked to. Changing this forces a new interface to be created. Only
 	// one of vpn_tunnel, interconnect_attachment or subnetwork can be specified.
-	// +crossplane:generate:reference:type=VPNTunnel
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.VPNTunnel
 	// +kubebuilder:validation:Optional
 	VPNTunnel *string `json:"vpnTunnel,omitempty" tf:"vpn_tunnel,omitempty"`
 
-	// Reference to a VPNTunnel to populate vpnTunnel.
+	// Reference to a VPNTunnel in compute to populate vpnTunnel.
 	// +kubebuilder:validation:Optional
 	VPNTunnelRef *v1.Reference `json:"vpnTunnelRef,omitempty" tf:"-"`
 
-	// Selector for a VPNTunnel to populate vpnTunnel.
+	// Selector for a VPNTunnel in compute to populate vpnTunnel.
 	// +kubebuilder:validation:Optional
 	VPNTunnelSelector *v1.Selector `json:"vpnTunnelSelector,omitempty" tf:"-"`
 }

--- a/apis/compute/v1beta1/zz_routernat_types.go
+++ b/apis/compute/v1beta1/zz_routernat_types.go
@@ -339,15 +339,15 @@ type RouterNATParameters struct {
 	Region *string `json:"region" tf:"region,omitempty"`
 
 	// The name of the Cloud Router in which this NAT will be configured.
-	// +crossplane:generate:reference:type=Router
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Router
 	// +kubebuilder:validation:Optional
 	Router *string `json:"router,omitempty" tf:"router,omitempty"`
 
-	// Reference to a Router to populate router.
+	// Reference to a Router in compute to populate router.
 	// +kubebuilder:validation:Optional
 	RouterRef *v1.Reference `json:"routerRef,omitempty" tf:"-"`
 
-	// Selector for a Router to populate router.
+	// Selector for a Router in compute to populate router.
 	// +kubebuilder:validation:Optional
 	RouterSelector *v1.Selector `json:"routerSelector,omitempty" tf:"-"`
 
@@ -472,14 +472,14 @@ type RulesParameters struct {
 type SubnetworkInitParameters struct {
 
 	// Self-link of subnetwork to NAT
-	// +crossplane:generate:reference:type=Subnetwork
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Subnetwork
 	Name *string `json:"name,omitempty" tf:"name,omitempty"`
 
-	// Reference to a Subnetwork to populate name.
+	// Reference to a Subnetwork in compute to populate name.
 	// +kubebuilder:validation:Optional
 	NameRef *v1.Reference `json:"nameRef,omitempty" tf:"-"`
 
-	// Selector for a Subnetwork to populate name.
+	// Selector for a Subnetwork in compute to populate name.
 	// +kubebuilder:validation:Optional
 	NameSelector *v1.Selector `json:"nameSelector,omitempty" tf:"-"`
 
@@ -521,15 +521,15 @@ type SubnetworkObservation struct {
 type SubnetworkParameters struct {
 
 	// Self-link of subnetwork to NAT
-	// +crossplane:generate:reference:type=Subnetwork
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Subnetwork
 	// +kubebuilder:validation:Optional
 	Name *string `json:"name,omitempty" tf:"name,omitempty"`
 
-	// Reference to a Subnetwork to populate name.
+	// Reference to a Subnetwork in compute to populate name.
 	// +kubebuilder:validation:Optional
 	NameRef *v1.Reference `json:"nameRef,omitempty" tf:"-"`
 
-	// Selector for a Subnetwork to populate name.
+	// Selector for a Subnetwork in compute to populate name.
 	// +kubebuilder:validation:Optional
 	NameSelector *v1.Selector `json:"nameSelector,omitempty" tf:"-"`
 

--- a/apis/compute/v1beta1/zz_serviceattachment_types.go
+++ b/apis/compute/v1beta1/zz_serviceattachment_types.go
@@ -93,14 +93,14 @@ type ServiceAttachmentInitParameters struct {
 	EnableProxyProtocol *bool `json:"enableProxyProtocol,omitempty" tf:"enable_proxy_protocol,omitempty"`
 
 	// An array of subnets that is provided for NAT in this service attachment.
-	// +crossplane:generate:reference:type=Subnetwork
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Subnetwork
 	NATSubnets []*string `json:"natSubnets,omitempty" tf:"nat_subnets,omitempty"`
 
-	// References to Subnetwork to populate natSubnets.
+	// References to Subnetwork in compute to populate natSubnets.
 	// +kubebuilder:validation:Optional
 	NATSubnetsRefs []v1.Reference `json:"natSubnetsRefs,omitempty" tf:"-"`
 
-	// Selector for a list of Subnetwork to populate natSubnets.
+	// Selector for a list of Subnetwork in compute to populate natSubnets.
 	// +kubebuilder:validation:Optional
 	NATSubnetsSelector *v1.Selector `json:"natSubnetsSelector,omitempty" tf:"-"`
 
@@ -228,15 +228,15 @@ type ServiceAttachmentParameters struct {
 	EnableProxyProtocol *bool `json:"enableProxyProtocol,omitempty" tf:"enable_proxy_protocol,omitempty"`
 
 	// An array of subnets that is provided for NAT in this service attachment.
-	// +crossplane:generate:reference:type=Subnetwork
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Subnetwork
 	// +kubebuilder:validation:Optional
 	NATSubnets []*string `json:"natSubnets,omitempty" tf:"nat_subnets,omitempty"`
 
-	// References to Subnetwork to populate natSubnets.
+	// References to Subnetwork in compute to populate natSubnets.
 	// +kubebuilder:validation:Optional
 	NATSubnetsRefs []v1.Reference `json:"natSubnetsRefs,omitempty" tf:"-"`
 
-	// Selector for a list of Subnetwork to populate natSubnets.
+	// Selector for a list of Subnetwork in compute to populate natSubnets.
 	// +kubebuilder:validation:Optional
 	NATSubnetsSelector *v1.Selector `json:"natSubnetsSelector,omitempty" tf:"-"`
 

--- a/apis/compute/v1beta1/zz_subnetwork_types.go
+++ b/apis/compute/v1beta1/zz_subnetwork_types.go
@@ -91,14 +91,14 @@ type SubnetworkInitParameters_2 struct {
 
 	// The network this subnet belongs to.
 	// Only networks that are in the distributed mode can have subnetworks.
-	// +crossplane:generate:reference:type=Network
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Network
 	Network *string `json:"network,omitempty" tf:"network,omitempty"`
 
-	// Reference to a Network to populate network.
+	// Reference to a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkRef *v1.Reference `json:"networkRef,omitempty" tf:"-"`
 
-	// Selector for a Network to populate network.
+	// Selector for a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkSelector *v1.Selector `json:"networkSelector,omitempty" tf:"-"`
 
@@ -397,15 +397,15 @@ type SubnetworkParameters_2 struct {
 
 	// The network this subnet belongs to.
 	// Only networks that are in the distributed mode can have subnetworks.
-	// +crossplane:generate:reference:type=Network
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Network
 	// +kubebuilder:validation:Optional
 	Network *string `json:"network,omitempty" tf:"network,omitempty"`
 
-	// Reference to a Network to populate network.
+	// Reference to a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkRef *v1.Reference `json:"networkRef,omitempty" tf:"-"`
 
-	// Selector for a Network to populate network.
+	// Selector for a Network in compute to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkSelector *v1.Selector `json:"networkSelector,omitempty" tf:"-"`
 

--- a/apis/compute/v1beta1/zz_subnetworkiammember_types.go
+++ b/apis/compute/v1beta1/zz_subnetworkiammember_types.go
@@ -52,14 +52,14 @@ type SubnetworkIAMMemberInitParameters struct {
 
 	Role *string `json:"role,omitempty" tf:"role,omitempty"`
 
-	// +crossplane:generate:reference:type=Subnetwork
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Subnetwork
 	Subnetwork *string `json:"subnetwork,omitempty" tf:"subnetwork,omitempty"`
 
-	// Reference to a Subnetwork to populate subnetwork.
+	// Reference to a Subnetwork in compute to populate subnetwork.
 	// +kubebuilder:validation:Optional
 	SubnetworkRef *v1.Reference `json:"subnetworkRef,omitempty" tf:"-"`
 
-	// Selector for a Subnetwork to populate subnetwork.
+	// Selector for a Subnetwork in compute to populate subnetwork.
 	// +kubebuilder:validation:Optional
 	SubnetworkSelector *v1.Selector `json:"subnetworkSelector,omitempty" tf:"-"`
 }
@@ -99,15 +99,15 @@ type SubnetworkIAMMemberParameters struct {
 	// +kubebuilder:validation:Optional
 	Role *string `json:"role,omitempty" tf:"role,omitempty"`
 
-	// +crossplane:generate:reference:type=Subnetwork
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Subnetwork
 	// +kubebuilder:validation:Optional
 	Subnetwork *string `json:"subnetwork,omitempty" tf:"subnetwork,omitempty"`
 
-	// Reference to a Subnetwork to populate subnetwork.
+	// Reference to a Subnetwork in compute to populate subnetwork.
 	// +kubebuilder:validation:Optional
 	SubnetworkRef *v1.Reference `json:"subnetworkRef,omitempty" tf:"-"`
 
-	// Selector for a Subnetwork to populate subnetwork.
+	// Selector for a Subnetwork in compute to populate subnetwork.
 	// +kubebuilder:validation:Optional
 	SubnetworkSelector *v1.Selector `json:"subnetworkSelector,omitempty" tf:"-"`
 }

--- a/apis/compute/v1beta1/zz_targethttpsproxy_types.go
+++ b/apis/compute/v1beta1/zz_targethttpsproxy_types.go
@@ -56,14 +56,14 @@ type TargetHTTPSProxyInitParameters struct {
 	// URLs to SslCertificate resources that are used to authenticate connections between users and the load balancer.
 	// Currently, you may specify up to 15 SSL certificates. sslCertificates do not apply when the load balancing scheme is set to INTERNAL_SELF_MANAGED.
 	// sslCertificates and certificateManagerCertificates can not be defined together.
-	// +crossplane:generate:reference:type=SSLCertificate
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.SSLCertificate
 	SSLCertificates []*string `json:"sslCertificates,omitempty" tf:"ssl_certificates,omitempty"`
 
-	// References to SSLCertificate to populate sslCertificates.
+	// References to SSLCertificate in compute to populate sslCertificates.
 	// +kubebuilder:validation:Optional
 	SSLCertificatesRefs []v1.Reference `json:"sslCertificatesRefs,omitempty" tf:"-"`
 
-	// Selector for a list of SSLCertificate to populate sslCertificates.
+	// Selector for a list of SSLCertificate in compute to populate sslCertificates.
 	// +kubebuilder:validation:Optional
 	SSLCertificatesSelector *v1.Selector `json:"sslCertificatesSelector,omitempty" tf:"-"`
 
@@ -226,15 +226,15 @@ type TargetHTTPSProxyParameters struct {
 	// URLs to SslCertificate resources that are used to authenticate connections between users and the load balancer.
 	// Currently, you may specify up to 15 SSL certificates. sslCertificates do not apply when the load balancing scheme is set to INTERNAL_SELF_MANAGED.
 	// sslCertificates and certificateManagerCertificates can not be defined together.
-	// +crossplane:generate:reference:type=SSLCertificate
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.SSLCertificate
 	// +kubebuilder:validation:Optional
 	SSLCertificates []*string `json:"sslCertificates,omitempty" tf:"ssl_certificates,omitempty"`
 
-	// References to SSLCertificate to populate sslCertificates.
+	// References to SSLCertificate in compute to populate sslCertificates.
 	// +kubebuilder:validation:Optional
 	SSLCertificatesRefs []v1.Reference `json:"sslCertificatesRefs,omitempty" tf:"-"`
 
-	// Selector for a list of SSLCertificate to populate sslCertificates.
+	// Selector for a list of SSLCertificate in compute to populate sslCertificates.
 	// +kubebuilder:validation:Optional
 	SSLCertificatesSelector *v1.Selector `json:"sslCertificatesSelector,omitempty" tf:"-"`
 

--- a/apis/compute/v1beta1/zz_targetpool_types.go
+++ b/apis/compute/v1beta1/zz_targetpool_types.go
@@ -28,14 +28,14 @@ type TargetPoolInitParameters struct {
 
 	// List of zero or one health check name or self_link. Only
 	// legacy google_compute_http_health_check is supported.
-	// +crossplane:generate:reference:type=HTTPHealthCheck
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.HTTPHealthCheck
 	HealthChecks []*string `json:"healthChecks,omitempty" tf:"health_checks,omitempty"`
 
-	// References to HTTPHealthCheck to populate healthChecks.
+	// References to HTTPHealthCheck in compute to populate healthChecks.
 	// +kubebuilder:validation:Optional
 	HealthChecksRefs []v1.Reference `json:"healthChecksRefs,omitempty" tf:"-"`
 
-	// Selector for a list of HTTPHealthCheck to populate healthChecks.
+	// Selector for a list of HTTPHealthCheck in compute to populate healthChecks.
 	// +kubebuilder:validation:Optional
 	HealthChecksSelector *v1.Selector `json:"healthChecksSelector,omitempty" tf:"-"`
 
@@ -114,15 +114,15 @@ type TargetPoolParameters struct {
 
 	// List of zero or one health check name or self_link. Only
 	// legacy google_compute_http_health_check is supported.
-	// +crossplane:generate:reference:type=HTTPHealthCheck
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.HTTPHealthCheck
 	// +kubebuilder:validation:Optional
 	HealthChecks []*string `json:"healthChecks,omitempty" tf:"health_checks,omitempty"`
 
-	// References to HTTPHealthCheck to populate healthChecks.
+	// References to HTTPHealthCheck in compute to populate healthChecks.
 	// +kubebuilder:validation:Optional
 	HealthChecksRefs []v1.Reference `json:"healthChecksRefs,omitempty" tf:"-"`
 
-	// Selector for a list of HTTPHealthCheck to populate healthChecks.
+	// Selector for a list of HTTPHealthCheck in compute to populate healthChecks.
 	// +kubebuilder:validation:Optional
 	HealthChecksSelector *v1.Selector `json:"healthChecksSelector,omitempty" tf:"-"`
 

--- a/apis/compute/v1beta1/zz_targetsslproxy_types.go
+++ b/apis/compute/v1beta1/zz_targetsslproxy_types.go
@@ -49,14 +49,14 @@ type TargetSSLProxyInitParameters struct {
 	// A list of SslCertificate resources that are used to authenticate
 	// connections between users and the load balancer. At least one
 	// SSL certificate must be specified.
-	// +crossplane:generate:reference:type=SSLCertificate
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.SSLCertificate
 	SSLCertificates []*string `json:"sslCertificates,omitempty" tf:"ssl_certificates,omitempty"`
 
-	// References to SSLCertificate to populate sslCertificates.
+	// References to SSLCertificate in compute to populate sslCertificates.
 	// +kubebuilder:validation:Optional
 	SSLCertificatesRefs []v1.Reference `json:"sslCertificatesRefs,omitempty" tf:"-"`
 
-	// Selector for a list of SSLCertificate to populate sslCertificates.
+	// Selector for a list of SSLCertificate in compute to populate sslCertificates.
 	// +kubebuilder:validation:Optional
 	SSLCertificatesSelector *v1.Selector `json:"sslCertificatesSelector,omitempty" tf:"-"`
 
@@ -153,15 +153,15 @@ type TargetSSLProxyParameters struct {
 	// A list of SslCertificate resources that are used to authenticate
 	// connections between users and the load balancer. At least one
 	// SSL certificate must be specified.
-	// +crossplane:generate:reference:type=SSLCertificate
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.SSLCertificate
 	// +kubebuilder:validation:Optional
 	SSLCertificates []*string `json:"sslCertificates,omitempty" tf:"ssl_certificates,omitempty"`
 
-	// References to SSLCertificate to populate sslCertificates.
+	// References to SSLCertificate in compute to populate sslCertificates.
 	// +kubebuilder:validation:Optional
 	SSLCertificatesRefs []v1.Reference `json:"sslCertificatesRefs,omitempty" tf:"-"`
 
-	// Selector for a list of SSLCertificate to populate sslCertificates.
+	// Selector for a list of SSLCertificate in compute to populate sslCertificates.
 	// +kubebuilder:validation:Optional
 	SSLCertificatesSelector *v1.Selector `json:"sslCertificatesSelector,omitempty" tf:"-"`
 

--- a/apis/compute/v1beta1/zz_vpntunnel_types.go
+++ b/apis/compute/v1beta1/zz_vpntunnel_types.go
@@ -37,17 +37,17 @@ type VPNTunnelInitParameters struct {
 	LocalTrafficSelector []*string `json:"localTrafficSelector,omitempty" tf:"local_traffic_selector,omitempty"`
 
 	// URL of the peer side external VPN gateway to which this VPN tunnel is connected.
-	// +crossplane:generate:reference:type=ExternalVPNGateway
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.ExternalVPNGateway
 	PeerExternalGateway *string `json:"peerExternalGateway,omitempty" tf:"peer_external_gateway,omitempty"`
 
 	// The interface ID of the external VPN gateway to which this VPN tunnel is connected.
 	PeerExternalGatewayInterface *float64 `json:"peerExternalGatewayInterface,omitempty" tf:"peer_external_gateway_interface,omitempty"`
 
-	// Reference to a ExternalVPNGateway to populate peerExternalGateway.
+	// Reference to a ExternalVPNGateway in compute to populate peerExternalGateway.
 	// +kubebuilder:validation:Optional
 	PeerExternalGatewayRef *v1.Reference `json:"peerExternalGatewayRef,omitempty" tf:"-"`
 
-	// Selector for a ExternalVPNGateway to populate peerExternalGateway.
+	// Selector for a ExternalVPNGateway in compute to populate peerExternalGateway.
 	// +kubebuilder:validation:Optional
 	PeerExternalGatewaySelector *v1.Selector `json:"peerExternalGatewaySelector,omitempty" tf:"-"`
 
@@ -72,14 +72,14 @@ type VPNTunnelInitParameters struct {
 	RemoteTrafficSelector []*string `json:"remoteTrafficSelector,omitempty" tf:"remote_traffic_selector,omitempty"`
 
 	// URL of router resource to be used for dynamic routing.
-	// +crossplane:generate:reference:type=Router
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Router
 	Router *string `json:"router,omitempty" tf:"router,omitempty"`
 
-	// Reference to a Router to populate router.
+	// Reference to a Router in compute to populate router.
 	// +kubebuilder:validation:Optional
 	RouterRef *v1.Reference `json:"routerRef,omitempty" tf:"-"`
 
-	// Selector for a Router to populate router.
+	// Selector for a Router in compute to populate router.
 	// +kubebuilder:validation:Optional
 	RouterSelector *v1.Selector `json:"routerSelector,omitempty" tf:"-"`
 
@@ -100,17 +100,17 @@ type VPNTunnelInitParameters struct {
 	// URL of the VPN gateway with which this VPN tunnel is associated.
 	// This must be used if a High Availability VPN gateway resource is created.
 	// This field must reference a google_compute_ha_vpn_gateway resource.
-	// +crossplane:generate:reference:type=HaVPNGateway
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.HaVPNGateway
 	VPNGateway *string `json:"vpnGateway,omitempty" tf:"vpn_gateway,omitempty"`
 
 	// The interface ID of the VPN gateway with which this VPN tunnel is associated.
 	VPNGatewayInterface *float64 `json:"vpnGatewayInterface,omitempty" tf:"vpn_gateway_interface,omitempty"`
 
-	// Reference to a HaVPNGateway to populate vpnGateway.
+	// Reference to a HaVPNGateway in compute to populate vpnGateway.
 	// +kubebuilder:validation:Optional
 	VPNGatewayRef *v1.Reference `json:"vpnGatewayRef,omitempty" tf:"-"`
 
-	// Selector for a HaVPNGateway to populate vpnGateway.
+	// Selector for a HaVPNGateway in compute to populate vpnGateway.
 	// +kubebuilder:validation:Optional
 	VPNGatewaySelector *v1.Selector `json:"vpnGatewaySelector,omitempty" tf:"-"`
 }
@@ -241,7 +241,7 @@ type VPNTunnelParameters struct {
 	LocalTrafficSelector []*string `json:"localTrafficSelector,omitempty" tf:"local_traffic_selector,omitempty"`
 
 	// URL of the peer side external VPN gateway to which this VPN tunnel is connected.
-	// +crossplane:generate:reference:type=ExternalVPNGateway
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.ExternalVPNGateway
 	// +kubebuilder:validation:Optional
 	PeerExternalGateway *string `json:"peerExternalGateway,omitempty" tf:"peer_external_gateway,omitempty"`
 
@@ -249,11 +249,11 @@ type VPNTunnelParameters struct {
 	// +kubebuilder:validation:Optional
 	PeerExternalGatewayInterface *float64 `json:"peerExternalGatewayInterface,omitempty" tf:"peer_external_gateway_interface,omitempty"`
 
-	// Reference to a ExternalVPNGateway to populate peerExternalGateway.
+	// Reference to a ExternalVPNGateway in compute to populate peerExternalGateway.
 	// +kubebuilder:validation:Optional
 	PeerExternalGatewayRef *v1.Reference `json:"peerExternalGatewayRef,omitempty" tf:"-"`
 
-	// Selector for a ExternalVPNGateway to populate peerExternalGateway.
+	// Selector for a ExternalVPNGateway in compute to populate peerExternalGateway.
 	// +kubebuilder:validation:Optional
 	PeerExternalGatewaySelector *v1.Selector `json:"peerExternalGatewaySelector,omitempty" tf:"-"`
 
@@ -286,15 +286,15 @@ type VPNTunnelParameters struct {
 	RemoteTrafficSelector []*string `json:"remoteTrafficSelector,omitempty" tf:"remote_traffic_selector,omitempty"`
 
 	// URL of router resource to be used for dynamic routing.
-	// +crossplane:generate:reference:type=Router
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Router
 	// +kubebuilder:validation:Optional
 	Router *string `json:"router,omitempty" tf:"router,omitempty"`
 
-	// Reference to a Router to populate router.
+	// Reference to a Router in compute to populate router.
 	// +kubebuilder:validation:Optional
 	RouterRef *v1.Reference `json:"routerRef,omitempty" tf:"-"`
 
-	// Selector for a Router to populate router.
+	// Selector for a Router in compute to populate router.
 	// +kubebuilder:validation:Optional
 	RouterSelector *v1.Selector `json:"routerSelector,omitempty" tf:"-"`
 
@@ -322,7 +322,7 @@ type VPNTunnelParameters struct {
 	// URL of the VPN gateway with which this VPN tunnel is associated.
 	// This must be used if a High Availability VPN gateway resource is created.
 	// This field must reference a google_compute_ha_vpn_gateway resource.
-	// +crossplane:generate:reference:type=HaVPNGateway
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.HaVPNGateway
 	// +kubebuilder:validation:Optional
 	VPNGateway *string `json:"vpnGateway,omitempty" tf:"vpn_gateway,omitempty"`
 
@@ -330,11 +330,11 @@ type VPNTunnelParameters struct {
 	// +kubebuilder:validation:Optional
 	VPNGatewayInterface *float64 `json:"vpnGatewayInterface,omitempty" tf:"vpn_gateway_interface,omitempty"`
 
-	// Reference to a HaVPNGateway to populate vpnGateway.
+	// Reference to a HaVPNGateway in compute to populate vpnGateway.
 	// +kubebuilder:validation:Optional
 	VPNGatewayRef *v1.Reference `json:"vpnGatewayRef,omitempty" tf:"-"`
 
-	// Selector for a HaVPNGateway to populate vpnGateway.
+	// Selector for a HaVPNGateway in compute to populate vpnGateway.
 	// +kubebuilder:validation:Optional
 	VPNGatewaySelector *v1.Selector `json:"vpnGatewaySelector,omitempty" tf:"-"`
 }

--- a/apis/container/v1beta1/zz_nodepool_types.go
+++ b/apis/container/v1beta1/zz_nodepool_types.go
@@ -1115,16 +1115,16 @@ type NodePoolParameters_2 struct {
 	Autoscaling []NodePoolAutoscalingParameters `json:"autoscaling,omitempty" tf:"autoscaling,omitempty"`
 
 	// The cluster to create the node pool for. Cluster must be present in location provided for clusters. May be specified in the format projects/{{project}}/locations/{{location}}/clusters/{{cluster}} or as just the name of the cluster.
-	// +crossplane:generate:reference:type=Cluster
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/container/v1beta1.Cluster
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	Cluster *string `json:"cluster,omitempty" tf:"cluster,omitempty"`
 
-	// Reference to a Cluster to populate cluster.
+	// Reference to a Cluster in container to populate cluster.
 	// +kubebuilder:validation:Optional
 	ClusterRef *v1.Reference `json:"clusterRef,omitempty" tf:"-"`
 
-	// Selector for a Cluster to populate cluster.
+	// Selector for a Cluster in container to populate cluster.
 	// +kubebuilder:validation:Optional
 	ClusterSelector *v1.Selector `json:"clusterSelector,omitempty" tf:"-"`
 

--- a/apis/containeraws/v1beta1/zz_nodepool_types.go
+++ b/apis/containeraws/v1beta1/zz_nodepool_types.go
@@ -464,15 +464,15 @@ type NodePoolParameters struct {
 	Autoscaling []AutoscalingParameters `json:"autoscaling,omitempty" tf:"autoscaling,omitempty"`
 
 	// The awsCluster for the resource
-	// +crossplane:generate:reference:type=Cluster
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/containeraws/v1beta1.Cluster
 	// +kubebuilder:validation:Optional
 	Cluster *string `json:"cluster,omitempty" tf:"cluster,omitempty"`
 
-	// Reference to a Cluster to populate cluster.
+	// Reference to a Cluster in containeraws to populate cluster.
 	// +kubebuilder:validation:Optional
 	ClusterRef *v1.Reference `json:"clusterRef,omitempty" tf:"-"`
 
-	// Selector for a Cluster to populate cluster.
+	// Selector for a Cluster in containeraws to populate cluster.
 	// +kubebuilder:validation:Optional
 	ClusterSelector *v1.Selector `json:"clusterSelector,omitempty" tf:"-"`
 

--- a/apis/containerazure/v1beta1/zz_nodepool_types.go
+++ b/apis/containerazure/v1beta1/zz_nodepool_types.go
@@ -330,15 +330,15 @@ type NodePoolParameters struct {
 	AzureAvailabilityZone *string `json:"azureAvailabilityZone,omitempty" tf:"azure_availability_zone,omitempty"`
 
 	// The azureCluster for the resource
-	// +crossplane:generate:reference:type=Cluster
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/containerazure/v1beta1.Cluster
 	// +kubebuilder:validation:Optional
 	Cluster *string `json:"cluster,omitempty" tf:"cluster,omitempty"`
 
-	// Reference to a Cluster to populate cluster.
+	// Reference to a Cluster in containerazure to populate cluster.
 	// +kubebuilder:validation:Optional
 	ClusterRef *v1.Reference `json:"clusterRef,omitempty" tf:"-"`
 
-	// Selector for a Cluster to populate cluster.
+	// Selector for a Cluster in containerazure to populate cluster.
 	// +kubebuilder:validation:Optional
 	ClusterSelector *v1.Selector `json:"clusterSelector,omitempty" tf:"-"`
 

--- a/apis/firebaserules/v1beta1/zz_release_types.go
+++ b/apis/firebaserules/v1beta1/zz_release_types.go
@@ -19,14 +19,14 @@ type ReleaseInitParameters struct {
 	Project *string `json:"project,omitempty" tf:"project,omitempty"`
 
 	// Name of the Ruleset referred to by this Release. The Ruleset must exist for the Release to be created.
-	// +crossplane:generate:reference:type=Ruleset
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/firebaserules/v1beta1.Ruleset
 	RulesetName *string `json:"rulesetName,omitempty" tf:"ruleset_name,omitempty"`
 
-	// Reference to a Ruleset to populate rulesetName.
+	// Reference to a Ruleset in firebaserules to populate rulesetName.
 	// +kubebuilder:validation:Optional
 	RulesetNameRef *v1.Reference `json:"rulesetNameRef,omitempty" tf:"-"`
 
-	// Selector for a Ruleset to populate rulesetName.
+	// Selector for a Ruleset in firebaserules to populate rulesetName.
 	// +kubebuilder:validation:Optional
 	RulesetNameSelector *v1.Selector `json:"rulesetNameSelector,omitempty" tf:"-"`
 }
@@ -59,15 +59,15 @@ type ReleaseParameters struct {
 	Project *string `json:"project,omitempty" tf:"project,omitempty"`
 
 	// Name of the Ruleset referred to by this Release. The Ruleset must exist for the Release to be created.
-	// +crossplane:generate:reference:type=Ruleset
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/firebaserules/v1beta1.Ruleset
 	// +kubebuilder:validation:Optional
 	RulesetName *string `json:"rulesetName,omitempty" tf:"ruleset_name,omitempty"`
 
-	// Reference to a Ruleset to populate rulesetName.
+	// Reference to a Ruleset in firebaserules to populate rulesetName.
 	// +kubebuilder:validation:Optional
 	RulesetNameRef *v1.Reference `json:"rulesetNameRef,omitempty" tf:"-"`
 
-	// Selector for a Ruleset to populate rulesetName.
+	// Selector for a Ruleset in firebaserules to populate rulesetName.
 	// +kubebuilder:validation:Optional
 	RulesetNameSelector *v1.Selector `json:"rulesetNameSelector,omitempty" tf:"-"`
 }

--- a/apis/kms/v1beta1/zz_cryptokeyiammember_types.go
+++ b/apis/kms/v1beta1/zz_cryptokeyiammember_types.go
@@ -44,15 +44,15 @@ type ConditionParameters struct {
 type CryptoKeyIAMMemberInitParameters struct {
 	Condition []ConditionInitParameters `json:"condition,omitempty" tf:"condition,omitempty"`
 
-	// +crossplane:generate:reference:type=CryptoKey
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/kms/v1beta1.CryptoKey
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	CryptoKeyID *string `json:"cryptoKeyId,omitempty" tf:"crypto_key_id,omitempty"`
 
-	// Reference to a CryptoKey to populate cryptoKeyId.
+	// Reference to a CryptoKey in kms to populate cryptoKeyId.
 	// +kubebuilder:validation:Optional
 	CryptoKeyIDRef *v1.Reference `json:"cryptoKeyIdRef,omitempty" tf:"-"`
 
-	// Selector for a CryptoKey to populate cryptoKeyId.
+	// Selector for a CryptoKey in kms to populate cryptoKeyId.
 	// +kubebuilder:validation:Optional
 	CryptoKeyIDSelector *v1.Selector `json:"cryptoKeyIdSelector,omitempty" tf:"-"`
 
@@ -80,16 +80,16 @@ type CryptoKeyIAMMemberParameters struct {
 	// +kubebuilder:validation:Optional
 	Condition []ConditionParameters `json:"condition,omitempty" tf:"condition,omitempty"`
 
-	// +crossplane:generate:reference:type=CryptoKey
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/kms/v1beta1.CryptoKey
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	CryptoKeyID *string `json:"cryptoKeyId,omitempty" tf:"crypto_key_id,omitempty"`
 
-	// Reference to a CryptoKey to populate cryptoKeyId.
+	// Reference to a CryptoKey in kms to populate cryptoKeyId.
 	// +kubebuilder:validation:Optional
 	CryptoKeyIDRef *v1.Reference `json:"cryptoKeyIdRef,omitempty" tf:"-"`
 
-	// Selector for a CryptoKey to populate cryptoKeyId.
+	// Selector for a CryptoKey in kms to populate cryptoKeyId.
 	// +kubebuilder:validation:Optional
 	CryptoKeyIDSelector *v1.Selector `json:"cryptoKeyIdSelector,omitempty" tf:"-"`
 

--- a/apis/kms/v1beta1/zz_keyringiammember_types.go
+++ b/apis/kms/v1beta1/zz_keyringiammember_types.go
@@ -44,15 +44,15 @@ type KeyRingIAMMemberConditionParameters struct {
 type KeyRingIAMMemberInitParameters struct {
 	Condition []KeyRingIAMMemberConditionInitParameters `json:"condition,omitempty" tf:"condition,omitempty"`
 
-	// +crossplane:generate:reference:type=KeyRing
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/kms/v1beta1.KeyRing
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	KeyRingID *string `json:"keyRingId,omitempty" tf:"key_ring_id,omitempty"`
 
-	// Reference to a KeyRing to populate keyRingId.
+	// Reference to a KeyRing in kms to populate keyRingId.
 	// +kubebuilder:validation:Optional
 	KeyRingIDRef *v1.Reference `json:"keyRingIdRef,omitempty" tf:"-"`
 
-	// Selector for a KeyRing to populate keyRingId.
+	// Selector for a KeyRing in kms to populate keyRingId.
 	// +kubebuilder:validation:Optional
 	KeyRingIDSelector *v1.Selector `json:"keyRingIdSelector,omitempty" tf:"-"`
 
@@ -80,16 +80,16 @@ type KeyRingIAMMemberParameters struct {
 	// +kubebuilder:validation:Optional
 	Condition []KeyRingIAMMemberConditionParameters `json:"condition,omitempty" tf:"condition,omitempty"`
 
-	// +crossplane:generate:reference:type=KeyRing
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/kms/v1beta1.KeyRing
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	KeyRingID *string `json:"keyRingId,omitempty" tf:"key_ring_id,omitempty"`
 
-	// Reference to a KeyRing to populate keyRingId.
+	// Reference to a KeyRing in kms to populate keyRingId.
 	// +kubebuilder:validation:Optional
 	KeyRingIDRef *v1.Reference `json:"keyRingIdRef,omitempty" tf:"-"`
 
-	// Selector for a KeyRing to populate keyRingId.
+	// Selector for a KeyRing in kms to populate keyRingId.
 	// +kubebuilder:validation:Optional
 	KeyRingIDSelector *v1.Selector `json:"keyRingIdSelector,omitempty" tf:"-"`
 

--- a/apis/kms/v1beta1/zz_keyringimportjob_types.go
+++ b/apis/kms/v1beta1/zz_keyringimportjob_types.go
@@ -91,16 +91,16 @@ type KeyRingImportJobParameters struct {
 
 	// The KeyRing that this import job belongs to.
 	// Format: 'projects/{{project}}/locations/{{location}}/keyRings/{{keyRing}}'.
-	// +crossplane:generate:reference:type=KeyRing
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/kms/v1beta1.KeyRing
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	KeyRing *string `json:"keyRing,omitempty" tf:"key_ring,omitempty"`
 
-	// Reference to a KeyRing to populate keyRing.
+	// Reference to a KeyRing in kms to populate keyRing.
 	// +kubebuilder:validation:Optional
 	KeyRingRef *v1.Reference `json:"keyRingRef,omitempty" tf:"-"`
 
-	// Selector for a KeyRing to populate keyRing.
+	// Selector for a KeyRing in kms to populate keyRing.
 	// +kubebuilder:validation:Optional
 	KeyRingSelector *v1.Selector `json:"keyRingSelector,omitempty" tf:"-"`
 

--- a/apis/notebooks/v1beta1/zz_instanceiammember_types.go
+++ b/apis/notebooks/v1beta1/zz_instanceiammember_types.go
@@ -44,14 +44,14 @@ type ConditionParameters struct {
 type InstanceIAMMemberInitParameters struct {
 	Condition []ConditionInitParameters `json:"condition,omitempty" tf:"condition,omitempty"`
 
-	// +crossplane:generate:reference:type=Instance
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/notebooks/v1beta1.Instance
 	InstanceName *string `json:"instanceName,omitempty" tf:"instance_name,omitempty"`
 
-	// Reference to a Instance to populate instanceName.
+	// Reference to a Instance in notebooks to populate instanceName.
 	// +kubebuilder:validation:Optional
 	InstanceNameRef *v1.Reference `json:"instanceNameRef,omitempty" tf:"-"`
 
-	// Selector for a Instance to populate instanceName.
+	// Selector for a Instance in notebooks to populate instanceName.
 	// +kubebuilder:validation:Optional
 	InstanceNameSelector *v1.Selector `json:"instanceNameSelector,omitempty" tf:"-"`
 
@@ -87,15 +87,15 @@ type InstanceIAMMemberParameters struct {
 	// +kubebuilder:validation:Optional
 	Condition []ConditionParameters `json:"condition,omitempty" tf:"condition,omitempty"`
 
-	// +crossplane:generate:reference:type=Instance
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/notebooks/v1beta1.Instance
 	// +kubebuilder:validation:Optional
 	InstanceName *string `json:"instanceName,omitempty" tf:"instance_name,omitempty"`
 
-	// Reference to a Instance to populate instanceName.
+	// Reference to a Instance in notebooks to populate instanceName.
 	// +kubebuilder:validation:Optional
 	InstanceNameRef *v1.Reference `json:"instanceNameRef,omitempty" tf:"-"`
 
-	// Selector for a Instance to populate instanceName.
+	// Selector for a Instance in notebooks to populate instanceName.
 	// +kubebuilder:validation:Optional
 	InstanceNameSelector *v1.Selector `json:"instanceNameSelector,omitempty" tf:"-"`
 

--- a/apis/notebooks/v1beta1/zz_runtimeiammember_types.go
+++ b/apis/notebooks/v1beta1/zz_runtimeiammember_types.go
@@ -52,14 +52,14 @@ type RuntimeIAMMemberInitParameters struct {
 
 	Role *string `json:"role,omitempty" tf:"role,omitempty"`
 
-	// +crossplane:generate:reference:type=Runtime
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/notebooks/v1beta1.Runtime
 	RuntimeName *string `json:"runtimeName,omitempty" tf:"runtime_name,omitempty"`
 
-	// Reference to a Runtime to populate runtimeName.
+	// Reference to a Runtime in notebooks to populate runtimeName.
 	// +kubebuilder:validation:Optional
 	RuntimeNameRef *v1.Reference `json:"runtimeNameRef,omitempty" tf:"-"`
 
-	// Selector for a Runtime to populate runtimeName.
+	// Selector for a Runtime in notebooks to populate runtimeName.
 	// +kubebuilder:validation:Optional
 	RuntimeNameSelector *v1.Selector `json:"runtimeNameSelector,omitempty" tf:"-"`
 }
@@ -99,15 +99,15 @@ type RuntimeIAMMemberParameters struct {
 	// +kubebuilder:validation:Optional
 	Role *string `json:"role,omitempty" tf:"role,omitempty"`
 
-	// +crossplane:generate:reference:type=Runtime
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/notebooks/v1beta1.Runtime
 	// +kubebuilder:validation:Optional
 	RuntimeName *string `json:"runtimeName,omitempty" tf:"runtime_name,omitempty"`
 
-	// Reference to a Runtime to populate runtimeName.
+	// Reference to a Runtime in notebooks to populate runtimeName.
 	// +kubebuilder:validation:Optional
 	RuntimeNameRef *v1.Reference `json:"runtimeNameRef,omitempty" tf:"-"`
 
-	// Selector for a Runtime to populate runtimeName.
+	// Selector for a Runtime in notebooks to populate runtimeName.
 	// +kubebuilder:validation:Optional
 	RuntimeNameSelector *v1.Selector `json:"runtimeNameSelector,omitempty" tf:"-"`
 }

--- a/apis/privateca/v1beta1/zz_capooliammember_types.go
+++ b/apis/privateca/v1beta1/zz_capooliammember_types.go
@@ -15,15 +15,15 @@ import (
 
 type CAPoolIAMMemberInitParameters struct {
 
-	// +crossplane:generate:reference:type=CAPool
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/privateca/v1beta1.CAPool
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	CAPool *string `json:"caPool,omitempty" tf:"ca_pool,omitempty"`
 
-	// Reference to a CAPool to populate caPool.
+	// Reference to a CAPool in privateca to populate caPool.
 	// +kubebuilder:validation:Optional
 	CAPoolRef *v1.Reference `json:"caPoolRef,omitempty" tf:"-"`
 
-	// Selector for a CAPool to populate caPool.
+	// Selector for a CAPool in privateca to populate caPool.
 	// +kubebuilder:validation:Optional
 	CAPoolSelector *v1.Selector `json:"caPoolSelector,omitempty" tf:"-"`
 
@@ -58,16 +58,16 @@ type CAPoolIAMMemberObservation struct {
 
 type CAPoolIAMMemberParameters struct {
 
-	// +crossplane:generate:reference:type=CAPool
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/privateca/v1beta1.CAPool
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	CAPool *string `json:"caPool,omitempty" tf:"ca_pool,omitempty"`
 
-	// Reference to a CAPool to populate caPool.
+	// Reference to a CAPool in privateca to populate caPool.
 	// +kubebuilder:validation:Optional
 	CAPoolRef *v1.Reference `json:"caPoolRef,omitempty" tf:"-"`
 
-	// Selector for a CAPool to populate caPool.
+	// Selector for a CAPool in privateca to populate caPool.
 	// +kubebuilder:validation:Optional
 	CAPoolSelector *v1.Selector `json:"caPoolSelector,omitempty" tf:"-"`
 

--- a/apis/privateca/v1beta1/zz_certificate_types.go
+++ b/apis/privateca/v1beta1/zz_certificate_types.go
@@ -296,15 +296,15 @@ type CertificateParameters struct {
 	PemCsr *string `json:"pemCsr,omitempty" tf:"pem_csr,omitempty"`
 
 	// The name of the CaPool this Certificate belongs to.
-	// +crossplane:generate:reference:type=CAPool
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/privateca/v1beta1.CAPool
 	// +kubebuilder:validation:Optional
 	Pool *string `json:"pool,omitempty" tf:"pool,omitempty"`
 
-	// Reference to a CAPool to populate pool.
+	// Reference to a CAPool in privateca to populate pool.
 	// +kubebuilder:validation:Optional
 	PoolRef *v1.Reference `json:"poolRef,omitempty" tf:"-"`
 
-	// Selector for a CAPool to populate pool.
+	// Selector for a CAPool in privateca to populate pool.
 	// +kubebuilder:validation:Optional
 	PoolSelector *v1.Selector `json:"poolSelector,omitempty" tf:"-"`
 

--- a/apis/privateca/v1beta1/zz_certificateauthority_types.go
+++ b/apis/privateca/v1beta1/zz_certificateauthority_types.go
@@ -299,15 +299,15 @@ type CertificateAuthorityParameters struct {
 	PemCACertificate *string `json:"pemCaCertificate,omitempty" tf:"pem_ca_certificate,omitempty"`
 
 	// The name of the CaPool this Certificate Authority belongs to.
-	// +crossplane:generate:reference:type=CAPool
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/privateca/v1beta1.CAPool
 	// +kubebuilder:validation:Optional
 	Pool *string `json:"pool,omitempty" tf:"pool,omitempty"`
 
-	// Reference to a CAPool to populate pool.
+	// Reference to a CAPool in privateca to populate pool.
 	// +kubebuilder:validation:Optional
 	PoolRef *v1.Reference `json:"poolRef,omitempty" tf:"-"`
 
-	// Selector for a CAPool to populate pool.
+	// Selector for a CAPool in privateca to populate pool.
 	// +kubebuilder:validation:Optional
 	PoolSelector *v1.Selector `json:"poolSelector,omitempty" tf:"-"`
 

--- a/apis/privateca/v1beta1/zz_certificatetemplateiammember_types.go
+++ b/apis/privateca/v1beta1/zz_certificatetemplateiammember_types.go
@@ -43,15 +43,15 @@ type CertificateTemplateIAMMemberConditionParameters struct {
 
 type CertificateTemplateIAMMemberInitParameters struct {
 
-	// +crossplane:generate:reference:type=CertificateTemplate
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/privateca/v1beta1.CertificateTemplate
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	CertificateTemplate *string `json:"certificateTemplate,omitempty" tf:"certificate_template,omitempty"`
 
-	// Reference to a CertificateTemplate to populate certificateTemplate.
+	// Reference to a CertificateTemplate in privateca to populate certificateTemplate.
 	// +kubebuilder:validation:Optional
 	CertificateTemplateRef *v1.Reference `json:"certificateTemplateRef,omitempty" tf:"-"`
 
-	// Selector for a CertificateTemplate to populate certificateTemplate.
+	// Selector for a CertificateTemplate in privateca to populate certificateTemplate.
 	// +kubebuilder:validation:Optional
 	CertificateTemplateSelector *v1.Selector `json:"certificateTemplateSelector,omitempty" tf:"-"`
 
@@ -86,16 +86,16 @@ type CertificateTemplateIAMMemberObservation struct {
 
 type CertificateTemplateIAMMemberParameters struct {
 
-	// +crossplane:generate:reference:type=CertificateTemplate
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/privateca/v1beta1.CertificateTemplate
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	CertificateTemplate *string `json:"certificateTemplate,omitempty" tf:"certificate_template,omitempty"`
 
-	// Reference to a CertificateTemplate to populate certificateTemplate.
+	// Reference to a CertificateTemplate in privateca to populate certificateTemplate.
 	// +kubebuilder:validation:Optional
 	CertificateTemplateRef *v1.Reference `json:"certificateTemplateRef,omitempty" tf:"-"`
 
-	// Selector for a CertificateTemplate to populate certificateTemplate.
+	// Selector for a CertificateTemplate in privateca to populate certificateTemplate.
 	// +kubebuilder:validation:Optional
 	CertificateTemplateSelector *v1.Selector `json:"certificateTemplateSelector,omitempty" tf:"-"`
 

--- a/apis/pubsub/v1beta1/zz_litesubscription_types.go
+++ b/apis/pubsub/v1beta1/zz_litesubscription_types.go
@@ -49,14 +49,14 @@ type LiteSubscriptionInitParameters struct {
 	Region *string `json:"region,omitempty" tf:"region,omitempty"`
 
 	// A reference to a Topic resource.
-	// +crossplane:generate:reference:type=LiteTopic
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/pubsub/v1beta1.LiteTopic
 	Topic *string `json:"topic,omitempty" tf:"topic,omitempty"`
 
-	// Reference to a LiteTopic to populate topic.
+	// Reference to a LiteTopic in pubsub to populate topic.
 	// +kubebuilder:validation:Optional
 	TopicRef *v1.Reference `json:"topicRef,omitempty" tf:"-"`
 
-	// Selector for a LiteTopic to populate topic.
+	// Selector for a LiteTopic in pubsub to populate topic.
 	// +kubebuilder:validation:Optional
 	TopicSelector *v1.Selector `json:"topicSelector,omitempty" tf:"-"`
 }
@@ -101,15 +101,15 @@ type LiteSubscriptionParameters struct {
 	Region *string `json:"region,omitempty" tf:"region,omitempty"`
 
 	// A reference to a Topic resource.
-	// +crossplane:generate:reference:type=LiteTopic
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/pubsub/v1beta1.LiteTopic
 	// +kubebuilder:validation:Optional
 	Topic *string `json:"topic,omitempty" tf:"topic,omitempty"`
 
-	// Reference to a LiteTopic to populate topic.
+	// Reference to a LiteTopic in pubsub to populate topic.
 	// +kubebuilder:validation:Optional
 	TopicRef *v1.Reference `json:"topicRef,omitempty" tf:"-"`
 
-	// Selector for a LiteTopic to populate topic.
+	// Selector for a LiteTopic in pubsub to populate topic.
 	// +kubebuilder:validation:Optional
 	TopicSelector *v1.Selector `json:"topicSelector,omitempty" tf:"-"`
 

--- a/apis/pubsub/v1beta1/zz_litetopic_types.go
+++ b/apis/pubsub/v1beta1/zz_litetopic_types.go
@@ -158,14 +158,14 @@ type PartitionConfigParameters struct {
 type ReservationConfigInitParameters struct {
 
 	// The Reservation to use for this topic's throughput capacity.
-	// +crossplane:generate:reference:type=LiteReservation
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/pubsub/v1beta1.LiteReservation
 	ThroughputReservation *string `json:"throughputReservation,omitempty" tf:"throughput_reservation,omitempty"`
 
-	// Reference to a LiteReservation to populate throughputReservation.
+	// Reference to a LiteReservation in pubsub to populate throughputReservation.
 	// +kubebuilder:validation:Optional
 	ThroughputReservationRef *v1.Reference `json:"throughputReservationRef,omitempty" tf:"-"`
 
-	// Selector for a LiteReservation to populate throughputReservation.
+	// Selector for a LiteReservation in pubsub to populate throughputReservation.
 	// +kubebuilder:validation:Optional
 	ThroughputReservationSelector *v1.Selector `json:"throughputReservationSelector,omitempty" tf:"-"`
 }
@@ -179,15 +179,15 @@ type ReservationConfigObservation struct {
 type ReservationConfigParameters struct {
 
 	// The Reservation to use for this topic's throughput capacity.
-	// +crossplane:generate:reference:type=LiteReservation
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/pubsub/v1beta1.LiteReservation
 	// +kubebuilder:validation:Optional
 	ThroughputReservation *string `json:"throughputReservation,omitempty" tf:"throughput_reservation,omitempty"`
 
-	// Reference to a LiteReservation to populate throughputReservation.
+	// Reference to a LiteReservation in pubsub to populate throughputReservation.
 	// +kubebuilder:validation:Optional
 	ThroughputReservationRef *v1.Reference `json:"throughputReservationRef,omitempty" tf:"-"`
 
-	// Selector for a LiteReservation to populate throughputReservation.
+	// Selector for a LiteReservation in pubsub to populate throughputReservation.
 	// +kubebuilder:validation:Optional
 	ThroughputReservationSelector *v1.Selector `json:"throughputReservationSelector,omitempty" tf:"-"`
 }

--- a/apis/pubsub/v1beta1/zz_subscription_types.go
+++ b/apis/pubsub/v1beta1/zz_subscription_types.go
@@ -655,14 +655,14 @@ type SubscriptionInitParameters struct {
 	// A reference to a Topic resource, of the form projects/{project}/topics/{{name}}
 	// (as in the id property of a google_pubsub_topic), or just a topic name if
 	// the topic is in the same project as the subscription.
-	// +crossplane:generate:reference:type=Topic
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/pubsub/v1beta1.Topic
 	Topic *string `json:"topic,omitempty" tf:"topic,omitempty"`
 
-	// Reference to a Topic to populate topic.
+	// Reference to a Topic in pubsub to populate topic.
 	// +kubebuilder:validation:Optional
 	TopicRef *v1.Reference `json:"topicRef,omitempty" tf:"-"`
 
-	// Selector for a Topic to populate topic.
+	// Selector for a Topic in pubsub to populate topic.
 	// +kubebuilder:validation:Optional
 	TopicSelector *v1.Selector `json:"topicSelector,omitempty" tf:"-"`
 }
@@ -906,15 +906,15 @@ type SubscriptionParameters struct {
 	// A reference to a Topic resource, of the form projects/{project}/topics/{{name}}
 	// (as in the id property of a google_pubsub_topic), or just a topic name if
 	// the topic is in the same project as the subscription.
-	// +crossplane:generate:reference:type=Topic
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/pubsub/v1beta1.Topic
 	// +kubebuilder:validation:Optional
 	Topic *string `json:"topic,omitempty" tf:"topic,omitempty"`
 
-	// Reference to a Topic to populate topic.
+	// Reference to a Topic in pubsub to populate topic.
 	// +kubebuilder:validation:Optional
 	TopicRef *v1.Reference `json:"topicRef,omitempty" tf:"-"`
 
-	// Selector for a Topic to populate topic.
+	// Selector for a Topic in pubsub to populate topic.
 	// +kubebuilder:validation:Optional
 	TopicSelector *v1.Selector `json:"topicSelector,omitempty" tf:"-"`
 }

--- a/apis/pubsub/v1beta1/zz_subscriptioniammember_types.go
+++ b/apis/pubsub/v1beta1/zz_subscriptioniammember_types.go
@@ -50,14 +50,14 @@ type SubscriptionIAMMemberInitParameters struct {
 
 	Role *string `json:"role,omitempty" tf:"role,omitempty"`
 
-	// +crossplane:generate:reference:type=Subscription
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/pubsub/v1beta1.Subscription
 	Subscription *string `json:"subscription,omitempty" tf:"subscription,omitempty"`
 
-	// Reference to a Subscription to populate subscription.
+	// Reference to a Subscription in pubsub to populate subscription.
 	// +kubebuilder:validation:Optional
 	SubscriptionRef *v1.Reference `json:"subscriptionRef,omitempty" tf:"-"`
 
-	// Selector for a Subscription to populate subscription.
+	// Selector for a Subscription in pubsub to populate subscription.
 	// +kubebuilder:validation:Optional
 	SubscriptionSelector *v1.Selector `json:"subscriptionSelector,omitempty" tf:"-"`
 }
@@ -92,15 +92,15 @@ type SubscriptionIAMMemberParameters struct {
 	// +kubebuilder:validation:Optional
 	Role *string `json:"role,omitempty" tf:"role,omitempty"`
 
-	// +crossplane:generate:reference:type=Subscription
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/pubsub/v1beta1.Subscription
 	// +kubebuilder:validation:Optional
 	Subscription *string `json:"subscription,omitempty" tf:"subscription,omitempty"`
 
-	// Reference to a Subscription to populate subscription.
+	// Reference to a Subscription in pubsub to populate subscription.
 	// +kubebuilder:validation:Optional
 	SubscriptionRef *v1.Reference `json:"subscriptionRef,omitempty" tf:"-"`
 
-	// Selector for a Subscription to populate subscription.
+	// Selector for a Subscription in pubsub to populate subscription.
 	// +kubebuilder:validation:Optional
 	SubscriptionSelector *v1.Selector `json:"subscriptionSelector,omitempty" tf:"-"`
 }

--- a/apis/pubsub/v1beta1/zz_topiciammember_types.go
+++ b/apis/pubsub/v1beta1/zz_topiciammember_types.go
@@ -50,14 +50,14 @@ type TopicIAMMemberInitParameters struct {
 
 	Role *string `json:"role,omitempty" tf:"role,omitempty"`
 
-	// +crossplane:generate:reference:type=Topic
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/pubsub/v1beta1.Topic
 	Topic *string `json:"topic,omitempty" tf:"topic,omitempty"`
 
-	// Reference to a Topic to populate topic.
+	// Reference to a Topic in pubsub to populate topic.
 	// +kubebuilder:validation:Optional
 	TopicRef *v1.Reference `json:"topicRef,omitempty" tf:"-"`
 
-	// Selector for a Topic to populate topic.
+	// Selector for a Topic in pubsub to populate topic.
 	// +kubebuilder:validation:Optional
 	TopicSelector *v1.Selector `json:"topicSelector,omitempty" tf:"-"`
 }
@@ -92,15 +92,15 @@ type TopicIAMMemberParameters struct {
 	// +kubebuilder:validation:Optional
 	Role *string `json:"role,omitempty" tf:"role,omitempty"`
 
-	// +crossplane:generate:reference:type=Topic
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/pubsub/v1beta1.Topic
 	// +kubebuilder:validation:Optional
 	Topic *string `json:"topic,omitempty" tf:"topic,omitempty"`
 
-	// Reference to a Topic to populate topic.
+	// Reference to a Topic in pubsub to populate topic.
 	// +kubebuilder:validation:Optional
 	TopicRef *v1.Reference `json:"topicRef,omitempty" tf:"-"`
 
-	// Selector for a Topic to populate topic.
+	// Selector for a Topic in pubsub to populate topic.
 	// +kubebuilder:validation:Optional
 	TopicSelector *v1.Selector `json:"topicSelector,omitempty" tf:"-"`
 }

--- a/apis/secretmanager/v1beta1/zz_secretiammember_types.go
+++ b/apis/secretmanager/v1beta1/zz_secretiammember_types.go
@@ -50,15 +50,15 @@ type SecretIAMMemberInitParameters struct {
 
 	Role *string `json:"role,omitempty" tf:"role,omitempty"`
 
-	// +crossplane:generate:reference:type=Secret
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/secretmanager/v1beta1.Secret
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	SecretID *string `json:"secretId,omitempty" tf:"secret_id,omitempty"`
 
-	// Reference to a Secret to populate secretId.
+	// Reference to a Secret in secretmanager to populate secretId.
 	// +kubebuilder:validation:Optional
 	SecretIDRef *v1.Reference `json:"secretIdRef,omitempty" tf:"-"`
 
-	// Selector for a Secret to populate secretId.
+	// Selector for a Secret in secretmanager to populate secretId.
 	// +kubebuilder:validation:Optional
 	SecretIDSelector *v1.Selector `json:"secretIdSelector,omitempty" tf:"-"`
 }
@@ -93,16 +93,16 @@ type SecretIAMMemberParameters struct {
 	// +kubebuilder:validation:Optional
 	Role *string `json:"role,omitempty" tf:"role,omitempty"`
 
-	// +crossplane:generate:reference:type=Secret
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/secretmanager/v1beta1.Secret
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	SecretID *string `json:"secretId,omitempty" tf:"secret_id,omitempty"`
 
-	// Reference to a Secret to populate secretId.
+	// Reference to a Secret in secretmanager to populate secretId.
 	// +kubebuilder:validation:Optional
 	SecretIDRef *v1.Reference `json:"secretIdRef,omitempty" tf:"-"`
 
-	// Selector for a Secret to populate secretId.
+	// Selector for a Secret in secretmanager to populate secretId.
 	// +kubebuilder:validation:Optional
 	SecretIDSelector *v1.Selector `json:"secretIdSelector,omitempty" tf:"-"`
 }

--- a/apis/secretmanager/v1beta1/zz_secretversion_types.go
+++ b/apis/secretmanager/v1beta1/zz_secretversion_types.go
@@ -27,15 +27,15 @@ type SecretVersionInitParameters struct {
 	IsSecretDataBase64 *bool `json:"isSecretDataBase64,omitempty" tf:"is_secret_data_base64,omitempty"`
 
 	// Secret Manager secret resource
-	// +crossplane:generate:reference:type=Secret
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/secretmanager/v1beta1.Secret
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	Secret *string `json:"secret,omitempty" tf:"secret,omitempty"`
 
-	// Reference to a Secret to populate secret.
+	// Reference to a Secret in secretmanager to populate secret.
 	// +kubebuilder:validation:Optional
 	SecretRef *v1.Reference `json:"secretRef,omitempty" tf:"-"`
 
-	// Selector for a Secret to populate secret.
+	// Selector for a Secret in secretmanager to populate secret.
 	// +kubebuilder:validation:Optional
 	SecretSelector *v1.Selector `json:"secretSelector,omitempty" tf:"-"`
 }
@@ -90,7 +90,7 @@ type SecretVersionParameters struct {
 	IsSecretDataBase64 *bool `json:"isSecretDataBase64,omitempty" tf:"is_secret_data_base64,omitempty"`
 
 	// Secret Manager secret resource
-	// +crossplane:generate:reference:type=Secret
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/secretmanager/v1beta1.Secret
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	Secret *string `json:"secret,omitempty" tf:"secret,omitempty"`
@@ -99,11 +99,11 @@ type SecretVersionParameters struct {
 	// +kubebuilder:validation:Optional
 	SecretDataSecretRef v1.SecretKeySelector `json:"secretDataSecretRef" tf:"-"`
 
-	// Reference to a Secret to populate secret.
+	// Reference to a Secret in secretmanager to populate secret.
 	// +kubebuilder:validation:Optional
 	SecretRef *v1.Reference `json:"secretRef,omitempty" tf:"-"`
 
-	// Selector for a Secret to populate secret.
+	// Selector for a Secret in secretmanager to populate secret.
 	// +kubebuilder:validation:Optional
 	SecretSelector *v1.Selector `json:"secretSelector,omitempty" tf:"-"`
 }

--- a/apis/sourcerepo/v1beta1/zz_repositoryiammember_types.go
+++ b/apis/sourcerepo/v1beta1/zz_repositoryiammember_types.go
@@ -48,14 +48,14 @@ type RepositoryIAMMemberInitParameters struct {
 
 	Project *string `json:"project,omitempty" tf:"project,omitempty"`
 
-	// +crossplane:generate:reference:type=Repository
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/sourcerepo/v1beta1.Repository
 	Repository *string `json:"repository,omitempty" tf:"repository,omitempty"`
 
-	// Reference to a Repository to populate repository.
+	// Reference to a Repository in sourcerepo to populate repository.
 	// +kubebuilder:validation:Optional
 	RepositoryRef *v1.Reference `json:"repositoryRef,omitempty" tf:"-"`
 
-	// Selector for a Repository to populate repository.
+	// Selector for a Repository in sourcerepo to populate repository.
 	// +kubebuilder:validation:Optional
 	RepositorySelector *v1.Selector `json:"repositorySelector,omitempty" tf:"-"`
 
@@ -89,15 +89,15 @@ type RepositoryIAMMemberParameters struct {
 	// +kubebuilder:validation:Optional
 	Project *string `json:"project,omitempty" tf:"project,omitempty"`
 
-	// +crossplane:generate:reference:type=Repository
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/sourcerepo/v1beta1.Repository
 	// +kubebuilder:validation:Optional
 	Repository *string `json:"repository,omitempty" tf:"repository,omitempty"`
 
-	// Reference to a Repository to populate repository.
+	// Reference to a Repository in sourcerepo to populate repository.
 	// +kubebuilder:validation:Optional
 	RepositoryRef *v1.Reference `json:"repositoryRef,omitempty" tf:"-"`
 
-	// Selector for a Repository to populate repository.
+	// Selector for a Repository in sourcerepo to populate repository.
 	// +kubebuilder:validation:Optional
 	RepositorySelector *v1.Selector `json:"repositorySelector,omitempty" tf:"-"`
 

--- a/apis/spanner/v1beta1/zz_databaseiammember_types.go
+++ b/apis/spanner/v1beta1/zz_databaseiammember_types.go
@@ -44,27 +44,27 @@ type ConditionParameters struct {
 type DatabaseIAMMemberInitParameters struct {
 	Condition []ConditionInitParameters `json:"condition,omitempty" tf:"condition,omitempty"`
 
-	// +crossplane:generate:reference:type=Database
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/spanner/v1beta1.Database
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	Database *string `json:"database,omitempty" tf:"database,omitempty"`
 
-	// Reference to a Database to populate database.
+	// Reference to a Database in spanner to populate database.
 	// +kubebuilder:validation:Optional
 	DatabaseRef *v1.Reference `json:"databaseRef,omitempty" tf:"-"`
 
-	// Selector for a Database to populate database.
+	// Selector for a Database in spanner to populate database.
 	// +kubebuilder:validation:Optional
 	DatabaseSelector *v1.Selector `json:"databaseSelector,omitempty" tf:"-"`
 
-	// +crossplane:generate:reference:type=Instance
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/spanner/v1beta1.Instance
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	Instance *string `json:"instance,omitempty" tf:"instance,omitempty"`
 
-	// Reference to a Instance to populate instance.
+	// Reference to a Instance in spanner to populate instance.
 	// +kubebuilder:validation:Optional
 	InstanceRef *v1.Reference `json:"instanceRef,omitempty" tf:"-"`
 
-	// Selector for a Instance to populate instance.
+	// Selector for a Instance in spanner to populate instance.
 	// +kubebuilder:validation:Optional
 	InstanceSelector *v1.Selector `json:"instanceSelector,omitempty" tf:"-"`
 
@@ -98,29 +98,29 @@ type DatabaseIAMMemberParameters struct {
 	// +kubebuilder:validation:Optional
 	Condition []ConditionParameters `json:"condition,omitempty" tf:"condition,omitempty"`
 
-	// +crossplane:generate:reference:type=Database
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/spanner/v1beta1.Database
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	Database *string `json:"database,omitempty" tf:"database,omitempty"`
 
-	// Reference to a Database to populate database.
+	// Reference to a Database in spanner to populate database.
 	// +kubebuilder:validation:Optional
 	DatabaseRef *v1.Reference `json:"databaseRef,omitempty" tf:"-"`
 
-	// Selector for a Database to populate database.
+	// Selector for a Database in spanner to populate database.
 	// +kubebuilder:validation:Optional
 	DatabaseSelector *v1.Selector `json:"databaseSelector,omitempty" tf:"-"`
 
-	// +crossplane:generate:reference:type=Instance
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/spanner/v1beta1.Instance
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	Instance *string `json:"instance,omitempty" tf:"instance,omitempty"`
 
-	// Reference to a Instance to populate instance.
+	// Reference to a Instance in spanner to populate instance.
 	// +kubebuilder:validation:Optional
 	InstanceRef *v1.Reference `json:"instanceRef,omitempty" tf:"-"`
 
-	// Selector for a Instance to populate instance.
+	// Selector for a Instance in spanner to populate instance.
 	// +kubebuilder:validation:Optional
 	InstanceSelector *v1.Selector `json:"instanceSelector,omitempty" tf:"-"`
 

--- a/apis/spanner/v1beta1/zz_instanceiammember_types.go
+++ b/apis/spanner/v1beta1/zz_instanceiammember_types.go
@@ -44,15 +44,15 @@ type InstanceIAMMemberConditionParameters struct {
 type InstanceIAMMemberInitParameters struct {
 	Condition []InstanceIAMMemberConditionInitParameters `json:"condition,omitempty" tf:"condition,omitempty"`
 
-	// +crossplane:generate:reference:type=Instance
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/spanner/v1beta1.Instance
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	Instance *string `json:"instance,omitempty" tf:"instance,omitempty"`
 
-	// Reference to a Instance to populate instance.
+	// Reference to a Instance in spanner to populate instance.
 	// +kubebuilder:validation:Optional
 	InstanceRef *v1.Reference `json:"instanceRef,omitempty" tf:"-"`
 
-	// Selector for a Instance to populate instance.
+	// Selector for a Instance in spanner to populate instance.
 	// +kubebuilder:validation:Optional
 	InstanceSelector *v1.Selector `json:"instanceSelector,omitempty" tf:"-"`
 
@@ -84,16 +84,16 @@ type InstanceIAMMemberParameters struct {
 	// +kubebuilder:validation:Optional
 	Condition []InstanceIAMMemberConditionParameters `json:"condition,omitempty" tf:"condition,omitempty"`
 
-	// +crossplane:generate:reference:type=Instance
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/spanner/v1beta1.Instance
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	Instance *string `json:"instance,omitempty" tf:"instance,omitempty"`
 
-	// Reference to a Instance to populate instance.
+	// Reference to a Instance in spanner to populate instance.
 	// +kubebuilder:validation:Optional
 	InstanceRef *v1.Reference `json:"instanceRef,omitempty" tf:"-"`
 
-	// Selector for a Instance to populate instance.
+	// Selector for a Instance in spanner to populate instance.
 	// +kubebuilder:validation:Optional
 	InstanceSelector *v1.Selector `json:"instanceSelector,omitempty" tf:"-"`
 

--- a/apis/sql/v1beta1/zz_database_types.go
+++ b/apis/sql/v1beta1/zz_database_types.go
@@ -104,15 +104,15 @@ type DatabaseParameters struct {
 
 	// The name of the Cloud SQL instance. This does not include the project
 	// ID.
-	// +crossplane:generate:reference:type=DatabaseInstance
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/sql/v1beta1.DatabaseInstance
 	// +kubebuilder:validation:Optional
 	Instance *string `json:"instance,omitempty" tf:"instance,omitempty"`
 
-	// Reference to a DatabaseInstance to populate instance.
+	// Reference to a DatabaseInstance in sql to populate instance.
 	// +kubebuilder:validation:Optional
 	InstanceRef *v1.Reference `json:"instanceRef,omitempty" tf:"-"`
 
-	// Selector for a DatabaseInstance to populate instance.
+	// Selector for a DatabaseInstance in sql to populate instance.
 	// +kubebuilder:validation:Optional
 	InstanceSelector *v1.Selector `json:"instanceSelector,omitempty" tf:"-"`
 

--- a/apis/sql/v1beta1/zz_sslcert_types.go
+++ b/apis/sql/v1beta1/zz_sslcert_types.go
@@ -21,14 +21,14 @@ type SSLCertInitParameters struct {
 
 	// The name of the Cloud SQL instance. Changing this
 	// forces a new resource to be created.
-	// +crossplane:generate:reference:type=DatabaseInstance
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/sql/v1beta1.DatabaseInstance
 	Instance *string `json:"instance,omitempty" tf:"instance,omitempty"`
 
-	// Reference to a DatabaseInstance to populate instance.
+	// Reference to a DatabaseInstance in sql to populate instance.
 	// +kubebuilder:validation:Optional
 	InstanceRef *v1.Reference `json:"instanceRef,omitempty" tf:"-"`
 
-	// Selector for a DatabaseInstance to populate instance.
+	// Selector for a DatabaseInstance in sql to populate instance.
 	// +kubebuilder:validation:Optional
 	InstanceSelector *v1.Selector `json:"instanceSelector,omitempty" tf:"-"`
 
@@ -77,15 +77,15 @@ type SSLCertParameters struct {
 
 	// The name of the Cloud SQL instance. Changing this
 	// forces a new resource to be created.
-	// +crossplane:generate:reference:type=DatabaseInstance
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/sql/v1beta1.DatabaseInstance
 	// +kubebuilder:validation:Optional
 	Instance *string `json:"instance,omitempty" tf:"instance,omitempty"`
 
-	// Reference to a DatabaseInstance to populate instance.
+	// Reference to a DatabaseInstance in sql to populate instance.
 	// +kubebuilder:validation:Optional
 	InstanceRef *v1.Reference `json:"instanceRef,omitempty" tf:"-"`
 
-	// Selector for a DatabaseInstance to populate instance.
+	// Selector for a DatabaseInstance in sql to populate instance.
 	// +kubebuilder:validation:Optional
 	InstanceSelector *v1.Selector `json:"instanceSelector,omitempty" tf:"-"`
 

--- a/apis/sql/v1beta1/zz_user_types.go
+++ b/apis/sql/v1beta1/zz_user_types.go
@@ -105,14 +105,14 @@ type UserInitParameters struct {
 
 	// The name of the Cloud SQL instance. Changing this
 	// forces a new resource to be created.
-	// +crossplane:generate:reference:type=DatabaseInstance
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/sql/v1beta1.DatabaseInstance
 	Instance *string `json:"instance,omitempty" tf:"instance,omitempty"`
 
-	// Reference to a DatabaseInstance to populate instance.
+	// Reference to a DatabaseInstance in sql to populate instance.
 	// +kubebuilder:validation:Optional
 	InstanceRef *v1.Reference `json:"instanceRef,omitempty" tf:"-"`
 
-	// Selector for a DatabaseInstance to populate instance.
+	// Selector for a DatabaseInstance in sql to populate instance.
 	// +kubebuilder:validation:Optional
 	InstanceSelector *v1.Selector `json:"instanceSelector,omitempty" tf:"-"`
 
@@ -176,15 +176,15 @@ type UserParameters struct {
 
 	// The name of the Cloud SQL instance. Changing this
 	// forces a new resource to be created.
-	// +crossplane:generate:reference:type=DatabaseInstance
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/sql/v1beta1.DatabaseInstance
 	// +kubebuilder:validation:Optional
 	Instance *string `json:"instance,omitempty" tf:"instance,omitempty"`
 
-	// Reference to a DatabaseInstance to populate instance.
+	// Reference to a DatabaseInstance in sql to populate instance.
 	// +kubebuilder:validation:Optional
 	InstanceRef *v1.Reference `json:"instanceRef,omitempty" tf:"-"`
 
-	// Selector for a DatabaseInstance to populate instance.
+	// Selector for a DatabaseInstance in sql to populate instance.
 	// +kubebuilder:validation:Optional
 	InstanceSelector *v1.Selector `json:"instanceSelector,omitempty" tf:"-"`
 

--- a/apis/storage/v1beta1/zz_bucketiammember_types.go
+++ b/apis/storage/v1beta1/zz_bucketiammember_types.go
@@ -43,14 +43,14 @@ type BucketIAMMemberConditionParameters struct {
 
 type BucketIAMMemberInitParameters struct {
 
-	// +crossplane:generate:reference:type=Bucket
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/storage/v1beta1.Bucket
 	Bucket *string `json:"bucket,omitempty" tf:"bucket,omitempty"`
 
-	// Reference to a Bucket to populate bucket.
+	// Reference to a Bucket in storage to populate bucket.
 	// +kubebuilder:validation:Optional
 	BucketRef *v1.Reference `json:"bucketRef,omitempty" tf:"-"`
 
-	// Selector for a Bucket to populate bucket.
+	// Selector for a Bucket in storage to populate bucket.
 	// +kubebuilder:validation:Optional
 	BucketSelector *v1.Selector `json:"bucketSelector,omitempty" tf:"-"`
 
@@ -77,15 +77,15 @@ type BucketIAMMemberObservation struct {
 
 type BucketIAMMemberParameters struct {
 
-	// +crossplane:generate:reference:type=Bucket
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/storage/v1beta1.Bucket
 	// +kubebuilder:validation:Optional
 	Bucket *string `json:"bucket,omitempty" tf:"bucket,omitempty"`
 
-	// Reference to a Bucket to populate bucket.
+	// Reference to a Bucket in storage to populate bucket.
 	// +kubebuilder:validation:Optional
 	BucketRef *v1.Reference `json:"bucketRef,omitempty" tf:"-"`
 
-	// Selector for a Bucket to populate bucket.
+	// Selector for a Bucket in storage to populate bucket.
 	// +kubebuilder:validation:Optional
 	BucketSelector *v1.Selector `json:"bucketSelector,omitempty" tf:"-"`
 

--- a/apis/storage/v1beta1/zz_bucketobject_types.go
+++ b/apis/storage/v1beta1/zz_bucketobject_types.go
@@ -16,14 +16,14 @@ import (
 type BucketObjectInitParameters struct {
 
 	// The name of the containing bucket.
-	// +crossplane:generate:reference:type=Bucket
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/storage/v1beta1.Bucket
 	Bucket *string `json:"bucket,omitempty" tf:"bucket,omitempty"`
 
-	// Reference to a Bucket to populate bucket.
+	// Reference to a Bucket in storage to populate bucket.
 	// +kubebuilder:validation:Optional
 	BucketRef *v1.Reference `json:"bucketRef,omitempty" tf:"-"`
 
-	// Selector for a Bucket to populate bucket.
+	// Selector for a Bucket in storage to populate bucket.
 	// +kubebuilder:validation:Optional
 	BucketSelector *v1.Selector `json:"bucketSelector,omitempty" tf:"-"`
 
@@ -163,15 +163,15 @@ type BucketObjectObservation struct {
 type BucketObjectParameters struct {
 
 	// The name of the containing bucket.
-	// +crossplane:generate:reference:type=Bucket
+	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/storage/v1beta1.Bucket
 	// +kubebuilder:validation:Optional
 	Bucket *string `json:"bucket,omitempty" tf:"bucket,omitempty"`
 
-	// Reference to a Bucket to populate bucket.
+	// Reference to a Bucket in storage to populate bucket.
 	// +kubebuilder:validation:Optional
 	BucketRef *v1.Reference `json:"bucketRef,omitempty" tf:"-"`
 
-	// Selector for a Bucket to populate bucket.
+	// Selector for a Bucket in storage to populate bucket.
 	// +kubebuilder:validation:Optional
 	BucketSelector *v1.Selector `json:"bucketSelector,omitempty" tf:"-"`
 

--- a/config/accesscontextmanager/config.go
+++ b/config/accesscontextmanager/config.go
@@ -13,10 +13,10 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("google_access_context_manager_service_perimeter", func(r *config.Resource) {
 		r.References["status.access_levels"] = config.Reference{
-			Type: "AccessLevel",
+			TerraformName: "google_access_context_manager_access_level",
 		}
 		r.References["spec.access_levels"] = config.Reference{
-			Type: "AccessLevel",
+			TerraformName: "google_access_context_manager_access_level",
 		}
 	})
 	p.AddResourceConfigurator("google_access_context_manager_service_perimeter_resource", func(r *config.Resource) {

--- a/config/cloudcomposer/config.go
+++ b/config/cloudcomposer/config.go
@@ -13,19 +13,19 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("google_composer_environment", func(r *config.Resource) {
 		r.References["project"] = config.Reference{
-			Type: "github.com/upbound/provider-gcp/apis/cloudplatform/v1beta1.Project",
+			TerraformName: "google_project",
 		}
 		r.References["node_config.network"] = config.Reference{
-			Type: "github.com/upbound/provider-gcp/apis/compute/v1beta1.Network",
+			TerraformName: "google_compute_network",
 		}
 		r.References["node_config.subnetwork"] = config.Reference{
-			Type: "github.com/upbound/provider-gcp/apis/compute/v1beta1.Subnetwork",
+			TerraformName: "google_compute_subnetwork",
 		}
 		r.References["node_config.service_account"] = config.Reference{
-			Type: "github.com/upbound/provider-gcp/apis/cloudplatform/v1beta1.ServiceAccount",
+			TerraformName: "google_service_account",
 		}
 		r.References["private_environment_config.cloud_composer_connection_subnetwork"] = config.Reference{
-			Type: "github.com/upbound/provider-gcp/apis/compute/v1beta1.Subnetwork",
+			TerraformName: "google_compute_subnetwork",
 		}
 		r.MarkAsRequired("region")
 	})

--- a/config/cloudfunctions/config.go
+++ b/config/cloudfunctions/config.go
@@ -27,13 +27,13 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("google_cloudfunctions_function_iam_binding", func(r *config.Resource) {
 		r.References["cloud_function"] = config.Reference{
-			Type: "Function",
+			TerraformName: "google_cloudfunctions_function",
 		}
 	})
 
 	p.AddResourceConfigurator("google_cloudfunctions_function_iam_member", func(r *config.Resource) {
 		r.References["cloud_function"] = config.Reference{
-			Type: "Function",
+			TerraformName: "google_cloudfunctions_function",
 		}
 	})
 }

--- a/config/cloudplatform/config.go
+++ b/config/cloudplatform/config.go
@@ -19,8 +19,8 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("google_folder_iam_member", func(r *config.Resource) {
 		r.References["folder"] = config.Reference{
-			Type:      "Folder",
-			Extractor: common.ExtractResourceIDFuncPath,
+			TerraformName: "google_folder",
+			Extractor:     common.ExtractResourceIDFuncPath,
 		}
 	})
 	p.AddResourceConfigurator("google_project", func(r *config.Resource) {
@@ -29,31 +29,31 @@ func Configure(p *config.Provider) {
 	})
 	p.AddResourceConfigurator("google_project_default_service_accounts", func(r *config.Resource) {
 		r.References["project"] = config.Reference{
-			Type: "Project",
+			TerraformName: "google_project",
 		}
 	})
 	p.AddResourceConfigurator("google_project_iam_member", func(r *config.Resource) {
 		r.References["project"] = config.Reference{
-			Type: "Project",
+			TerraformName: "google_project",
 		}
 	})
 	p.AddResourceConfigurator("google_project_iam_audit_config", func(r *config.Resource) {
 		r.References["project"] = config.Reference{
-			Type: "Project",
+			TerraformName: "google_project",
 		}
 	})
 	p.AddResourceConfigurator("google_project_service", func(r *config.Resource) {
 		r.References["project"] = config.Reference{
-			Type: "Project",
+			TerraformName: "google_project",
 		}
 	})
 	p.AddResourceConfigurator("google_project_usage_export_bucket", func(r *config.Resource) {
 		r.References["project"] = config.Reference{
-			Type: "Project",
+			TerraformName: "google_project",
 		}
 		// Note(donovanmuller): Upjet does not generate this reference automatically
 		r.References["bucket_name"] = config.Reference{
-			Type: "github.com/upbound/provider-gcp/apis/storage/v1beta1.Bucket",
+			TerraformName: "google_storage_bucket",
 		}
 	})
 	p.AddResourceConfigurator("google_service_account_key", func(r *config.Resource) {
@@ -81,8 +81,8 @@ func Configure(p *config.Provider) {
 			}, nil
 		}
 		r.References["service_account_id"] = config.Reference{
-			Type:      "ServiceAccount",
-			Extractor: common.ExtractResourceIDFuncPath,
+			TerraformName: "google_service_account",
+			Extractor:     common.ExtractResourceIDFuncPath,
 		}
 	})
 	p.AddResourceConfigurator("google_service_account", func(r *config.Resource) {
@@ -90,22 +90,22 @@ func Configure(p *config.Provider) {
 	})
 	p.AddResourceConfigurator("google_service_account_iam_policy", func(r *config.Resource) {
 		r.References["service_account_id"] = config.Reference{
-			Type:      "ServiceAccount",
-			Extractor: common.ExtractResourceIDFuncPath,
+			TerraformName: "google_service_account",
+			Extractor:     common.ExtractResourceIDFuncPath,
 		}
 		config.MarkAsRequired(r.TerraformResource, "service_account_id")
 	})
 	p.AddResourceConfigurator("google_service_account_iam_binding", func(r *config.Resource) {
 		r.References["service_account_id"] = config.Reference{
-			Type:      "ServiceAccount",
-			Extractor: common.ExtractResourceIDFuncPath,
+			TerraformName: "google_service_account",
+			Extractor:     common.ExtractResourceIDFuncPath,
 		}
 		config.MarkAsRequired(r.TerraformResource, "service_account_id")
 	})
 	p.AddResourceConfigurator("google_service_account_iam_member", func(r *config.Resource) {
 		r.References["service_account_id"] = config.Reference{
-			Type:      "ServiceAccount",
-			Extractor: common.ExtractResourceIDFuncPath,
+			TerraformName: "google_service_account",
+			Extractor:     common.ExtractResourceIDFuncPath,
 		}
 		config.MarkAsRequired(r.TerraformResource, "service_account_id")
 	})

--- a/config/cloudrun/config.go
+++ b/config/cloudrun/config.go
@@ -14,15 +14,15 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("google_cloud_run_domain_mapping", func(r *config.Resource) {
 		r.References["metadata.namespace"] = config.Reference{
-			Type: "github.com/upbound/provider-gcp/apis/cloudplatform/v1beta1.Project",
+			TerraformName: "google_project",
 		}
 		r.References["spec.route_name"] = config.Reference{
-			Type: "Service",
+			TerraformName: "google_cloud_run_service",
 		}
 	})
 	p.AddResourceConfigurator("google_cloud_run_service", func(r *config.Resource) {
 		r.References["metadata.namespace"] = config.Reference{
-			Type: "github.com/upbound/provider-gcp/apis/cloudplatform/v1beta1.Project",
+			TerraformName: "google_project",
 		}
 		// manually added because during the native bump from 4.22.0->4.48.0
 		// crddiff detected the ref fields were removed.
@@ -35,28 +35,28 @@ func Configure(p *config.Provider) {
 	})
 	p.AddResourceConfigurator("google_cloud_run_service_iam_policy", func(r *config.Resource) {
 		r.References["project"] = config.Reference{
-			Type: "github.com/upbound/provider-gcp/apis/cloudplatform/v1beta1.Project",
+			TerraformName: "google_project",
 		}
 		r.References["service"] = config.Reference{
-			Type: "Service",
+			TerraformName: "google_cloud_run_service",
 		}
 		config.MarkAsRequired(r.TerraformResource, "location")
 	})
 	p.AddResourceConfigurator("google_cloud_run_service_iam_binding", func(r *config.Resource) {
 		r.References["project"] = config.Reference{
-			Type: "github.com/upbound/provider-gcp/apis/cloudplatform/v1beta1.Project",
+			TerraformName: "google_project",
 		}
 		r.References["service"] = config.Reference{
-			Type: "Service",
+			TerraformName: "google_cloud_run_service",
 		}
 		config.MarkAsRequired(r.TerraformResource, "location")
 	})
 	p.AddResourceConfigurator("google_cloud_run_service_iam_member", func(r *config.Resource) {
 		r.References["project"] = config.Reference{
-			Type: "github.com/upbound/provider-gcp/apis/cloudplatform/v1beta1.Project",
+			TerraformName: "google_project",
 		}
 		r.References["service"] = config.Reference{
-			Type: "Service",
+			TerraformName: "google_cloud_run_service",
 		}
 		config.MarkAsRequired(r.TerraformResource, "location")
 	})

--- a/config/cloudscheduler/config.go
+++ b/config/cloudscheduler/config.go
@@ -14,7 +14,7 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("google_cloud_scheduler_job", func(r *config.Resource) {
 		r.References["pubsub_target.topic_name"] = config.Reference{
 			// Note(donovanmuller): What about support for 'pubsub/v1beta1.LiteTopic' reference?
-			Type: "github.com/upbound/provider-gcp/apis/pubsub/v1beta1.Topic",
+			TerraformName: "google_pubsub_topic",
 		}
 		r.MarkAsRequired("region")
 	})

--- a/config/cloudtasks/config.go
+++ b/config/cloudtasks/config.go
@@ -13,7 +13,7 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("google_cloud_tasks_queue", func(r *config.Resource) {
 		r.References["project"] = config.Reference{
-			Type: "github.com/upbound/provider-gcp/apis/cloudplatform/v1beta1.Project",
+			TerraformName: "google_project",
 		}
 		config.MarkAsRequired(r.TerraformResource, "location")
 	})

--- a/config/compute/config.go
+++ b/config/compute/config.go
@@ -38,12 +38,12 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 
 	p.AddResourceConfigurator("google_compute_backend_service", func(r *config.Resource) {
 		r.References["health_checks"] = config.Reference{
-			Type:      "HealthCheck",
-			Extractor: common.PathSelfLinkExtractor,
+			TerraformName: "google_compute_health_check",
+			Extractor:     common.PathSelfLinkExtractor,
 		}
 		r.References["backend.group"] = config.Reference{
-			Type:      "InstanceGroupManager",
-			Extractor: PathInstanceGroupExtractor,
+			TerraformName: "google_compute_instance_group_manager",
+			Extractor:     PathInstanceGroupExtractor,
 		}
 	})
 
@@ -57,68 +57,68 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 
 	p.AddResourceConfigurator("google_compute_disk_iam_member", func(r *config.Resource) {
 		r.References["name"] = config.Reference{
-			Type: "Disk",
+			TerraformName: "google_compute_disk",
 		}
 	})
 
 	p.AddResourceConfigurator("google_compute_shared_vpc_host_project", func(r *config.Resource) {
 		r.References["project"] = config.Reference{
-			Type:      "github.com/upbound/provider-gcp/apis/cloudplatform/v1beta1.Project",
-			Extractor: common.ExtractProjectIDFuncPath,
+			TerraformName: "google_project",
+			Extractor:     common.ExtractProjectIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("google_compute_shared_vpc_service_project", func(r *config.Resource) {
 		r.References["host_project"] = config.Reference{
-			Type:      "github.com/upbound/provider-gcp/apis/cloudplatform/v1beta1.Project",
-			Extractor: common.ExtractProjectIDFuncPath,
+			TerraformName: "google_project",
+			Extractor:     common.ExtractProjectIDFuncPath,
 		}
 		r.References["service_project"] = config.Reference{
-			Type:      "github.com/upbound/provider-gcp/apis/cloudplatform/v1beta1.Project",
-			Extractor: common.ExtractProjectIDFuncPath,
+			TerraformName: "google_project",
+			Extractor:     common.ExtractProjectIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("google_compute_subnetwork", func(r *config.Resource) {
 		r.References["network"] = config.Reference{
-			Type: "Network",
+			TerraformName: "google_compute_network",
 		}
 		config.MarkAsRequired(r.TerraformResource, "region")
 	})
 
 	p.AddResourceConfigurator("google_compute_address", func(r *config.Resource) {
 		r.References["network"] = config.Reference{
-			Type:      "Network",
-			Extractor: common.PathSelfLinkExtractor,
+			TerraformName: "google_compute_network",
+			Extractor:     common.PathSelfLinkExtractor,
 		}
 		r.References["subnetwork"] = config.Reference{
-			Type:      "Subnetwork",
-			Extractor: common.PathSelfLinkExtractor,
+			TerraformName: "google_compute_subnetwork",
+			Extractor:     common.PathSelfLinkExtractor,
 		}
 		config.MarkAsRequired(r.TerraformResource, "region")
 	})
 
 	p.AddResourceConfigurator("google_compute_firewall", func(r *config.Resource) {
 		r.References["network"] = config.Reference{
-			Type:      "Network",
-			Extractor: common.PathSelfLinkExtractor,
+			TerraformName: "google_compute_network",
+			Extractor:     common.PathSelfLinkExtractor,
 		}
 	})
 
 	p.AddResourceConfigurator("google_compute_router", func(r *config.Resource) {
 		r.References["network"] = config.Reference{
-			Type:      "Network",
-			Extractor: common.PathSelfLinkExtractor,
+			TerraformName: "google_compute_network",
+			Extractor:     common.PathSelfLinkExtractor,
 		}
 		config.MarkAsRequired(r.TerraformResource, "region")
 	})
 
 	p.AddResourceConfigurator("google_compute_router_nat", func(r *config.Resource) {
 		r.References["router"] = config.Reference{
-			Type: "Router",
+			TerraformName: "google_compute_router",
 		}
 		r.References["subnetwork.name"] = config.Reference{
-			Type: "Subnetwork",
+			TerraformName: "google_compute_subnetwork",
 		}
 		delete(r.References, "region")
 		config.MarkAsRequired(r.TerraformResource, "region")
@@ -130,10 +130,10 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 		// elements configured as nil, defaulting to map[string]string:
 		r.TerraformResource.Schema["metadata"].Elem = schema.TypeString
 		r.References["network_interface.network"] = config.Reference{
-			Type: "Network",
+			TerraformName: "google_compute_network",
 		}
 		r.References["network_interface.subnetwork"] = config.Reference{
-			Type: "Subnetwork",
+			TerraformName: "google_compute_subnetwork",
 		}
 
 		r.TerraformCustomDiff = func(diff *terraform.InstanceDiff, _ *terraform.InstanceState, _ *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
@@ -158,22 +158,22 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 			Schema["labels"].Elem = schema.TypeString
 
 		r.References["network_interface.network"] = config.Reference{
-			Type:      "Network",
-			Extractor: common.PathSelfLinkExtractor,
+			TerraformName: "google_compute_network",
+			Extractor:     common.PathSelfLinkExtractor,
 		}
 		r.References["network_interface.subnetwork"] = config.Reference{
-			Type:      "Subnetwork",
-			Extractor: common.PathSelfLinkExtractor,
+			TerraformName: "google_compute_subnetwork",
+			Extractor:     common.PathSelfLinkExtractor,
 		}
 		r.References["boot_disk.initialize_params.image"] = config.Reference{
-			Type: "Image",
+			TerraformName: "google_compute_image",
 		}
 		r.MarkAsRequired("zone")
 	})
 
 	p.AddResourceConfigurator("google_compute_instance_iam_member", func(r *config.Resource) {
 		r.References["instance_name"] = config.Reference{
-			Type: "Instance",
+			TerraformName: "google_compute_instance",
 		}
 	})
 
@@ -189,10 +189,10 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 		r.TerraformResource.Schema["metadata"].Elem = schema.TypeString
 
 		r.References["network_interface.network"] = config.Reference{
-			Type: "Network",
+			TerraformName: "google_compute_network",
 		}
 		r.References["network_interface.subnetwork"] = config.Reference{
-			Type: "Subnetwork",
+			TerraformName: "google_compute_subnetwork",
 		}
 		r.TerraformCustomDiff = func(diff *terraform.InstanceDiff, _ *terraform.InstanceState, _ *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
 			if diff == nil || diff.Destroy {
@@ -207,66 +207,66 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 
 	p.AddResourceConfigurator("google_compute_instance_group", func(r *config.Resource) {
 		r.References["network"] = config.Reference{
-			Type:      "Network",
-			Extractor: common.PathSelfLinkExtractor,
+			TerraformName: "google_compute_network",
+			Extractor:     common.PathSelfLinkExtractor,
 		}
 		r.MarkAsRequired("zone")
 	})
 
 	p.AddResourceConfigurator("google_compute_global_address", func(r *config.Resource) {
 		r.References["network"] = config.Reference{
-			Type:      "Network",
-			Extractor: common.ExtractResourceIDFuncPath,
+			TerraformName: "google_compute_network",
+			Extractor:     common.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("google_compute_ha_vpn_gateway", func(r *config.Resource) {
 		r.References["network"] = config.Reference{
-			Type:      "Network",
-			Extractor: common.ExtractResourceIDFuncPath,
+			TerraformName: "google_compute_network",
+			Extractor:     common.ExtractResourceIDFuncPath,
 		}
 		config.MarkAsRequired(r.TerraformResource, "region")
 	})
 
 	p.AddResourceConfigurator("google_compute_instance_from_template", func(r *config.Resource) {
 		r.References["source_instance_template"] = config.Reference{
-			Type:      "InstanceTemplate",
-			Extractor: common.ExtractResourceIDFuncPath,
+			TerraformName: "google_compute_instance_template",
+			Extractor:     common.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("google_compute_instance_group_manager", func(r *config.Resource) {
 		r.References["auto_healing_policies.health_check"] = config.Reference{
-			Type:      "HealthCheck",
-			Extractor: common.ExtractResourceIDFuncPath,
+			TerraformName: "google_compute_health_check",
+			Extractor:     common.ExtractResourceIDFuncPath,
 		}
 		r.References["version.instance_template"] = config.Reference{
-			Type:      "InstanceTemplate",
-			Extractor: common.ExtractResourceIDFuncPath,
+			TerraformName: "google_compute_instance_template",
+			Extractor:     common.ExtractResourceIDFuncPath,
 		}
 		r.References["target_pools"] = config.Reference{
-			Type:      "TargetPool",
-			Extractor: common.PathSelfLinkExtractor,
+			TerraformName: "google_compute_target_pool",
+			Extractor:     common.PathSelfLinkExtractor,
 		}
 		r.MarkAsRequired("zone")
 	})
 
 	p.AddResourceConfigurator("google_compute_interconnect_attachment", func(r *config.Resource) {
 		r.References["router"] = config.Reference{
-			Type:      "Router",
-			Extractor: common.PathSelfLinkExtractor,
+			TerraformName: "google_compute_router",
+			Extractor:     common.PathSelfLinkExtractor,
 		}
 		config.MarkAsRequired(r.TerraformResource, "region")
 	})
 
 	p.AddResourceConfigurator("google_compute_network_endpoint_group", func(r *config.Resource) {
 		r.References["network"] = config.Reference{
-			Type:      "Network",
-			Extractor: common.ExtractResourceIDFuncPath,
+			TerraformName: "google_compute_network",
+			Extractor:     common.ExtractResourceIDFuncPath,
 		}
 		r.References["subnetwork"] = config.Reference{
-			Type:      "Subnetwork",
-			Extractor: common.ExtractResourceIDFuncPath,
+			TerraformName: "google_compute_subnetwork",
+			Extractor:     common.ExtractResourceIDFuncPath,
 		}
 		r.MarkAsRequired("zone")
 	})
@@ -279,7 +279,7 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 		// Note(donovanmuller): Only legacy google_compute_http_health_check is supported
 		// see https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_target_pool#health_checks
 		r.References["health_checks"] = config.Reference{
-			Type: "HTTPHealthCheck",
+			TerraformName: "google_compute_http_health_check",
 		}
 		r.MarkAsRequired("region")
 	})
@@ -304,52 +304,52 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 		// Note(donovanmuller): See https://github.com/crossplane/upjet/issues/95
 		// BackendService is also a valid reference Type
 		r.References["backend_service"] = config.Reference{
-			Type:      "RegionBackendService",
-			Extractor: common.PathSelfLinkExtractor,
+			TerraformName: "google_compute_region_backend_service",
+			Extractor:     common.PathSelfLinkExtractor,
 		}
 		r.References["ip_address"] = config.Reference{
-			Type:      "Address",
-			Extractor: common.PathSelfLinkExtractor,
+			TerraformName: "google_compute_address",
+			Extractor:     common.PathSelfLinkExtractor,
 		}
 		r.References["network"] = config.Reference{
-			Type:      "Network",
-			Extractor: common.PathSelfLinkExtractor,
+			TerraformName: "google_compute_network",
+			Extractor:     common.PathSelfLinkExtractor,
 		}
 		r.References["subnetwork"] = config.Reference{
-			Type:      "Subnetwork",
-			Extractor: common.PathSelfLinkExtractor,
+			TerraformName: "google_compute_subnetwork",
+			Extractor:     common.PathSelfLinkExtractor,
 		}
 		r.References["target"] = config.Reference{
-			Type:      "RegionTargetHTTPProxy",
-			Extractor: common.PathSelfLinkExtractor,
+			TerraformName: "google_compute_region_target_http_proxy",
+			Extractor:     common.PathSelfLinkExtractor,
 		}
 		config.MarkAsRequired(r.TerraformResource, "region")
 	})
 
 	p.AddResourceConfigurator("google_compute_region_backend_service", func(r *config.Resource) {
 		r.References["health_checks"] = config.Reference{
-			Type:      "RegionHealthCheck",
-			Extractor: common.PathSelfLinkExtractor,
+			TerraformName: "google_compute_region_health_check",
+			Extractor:     common.PathSelfLinkExtractor,
 		}
 		r.References["backend.group"] = config.Reference{
-			Type:      "RegionInstanceGroupManager",
-			Extractor: PathInstanceGroupExtractor,
+			TerraformName: "google_compute_region_instance_group_manager",
+			Extractor:     PathInstanceGroupExtractor,
 		}
 		config.MarkAsRequired(r.TerraformResource, "region")
 	})
 
 	p.AddResourceConfigurator("google_compute_region_instance_group_manager", func(r *config.Resource) {
 		r.References["auto_healing_policies.health_check"] = config.Reference{
-			Type:      "HealthCheck",
-			Extractor: common.ExtractResourceIDFuncPath,
+			TerraformName: "google_compute_health_check",
+			Extractor:     common.ExtractResourceIDFuncPath,
 		}
 		r.References["version.instance_template"] = config.Reference{
-			Type:      "InstanceTemplate",
-			Extractor: common.ExtractResourceIDFuncPath,
+			TerraformName: "google_compute_instance_template",
+			Extractor:     common.ExtractResourceIDFuncPath,
 		}
 		r.References["target_pools"] = config.Reference{
-			Type:      "TargetPool",
-			Extractor: common.PathSelfLinkExtractor,
+			TerraformName: "google_compute_target_pool",
+			Extractor:     common.PathSelfLinkExtractor,
 		}
 		r.MarkAsRequired("region")
 	})
@@ -358,8 +358,8 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 		config.MarkAsRequired(r.TerraformResource, "region")
 
 		r.References["url_map"] = config.Reference{
-			Type:      "RegionURLMap",
-			Extractor: common.PathSelfLinkExtractor,
+			TerraformName: "google_compute_region_url_map",
+			Extractor:     common.PathSelfLinkExtractor,
 		}
 
 	})
@@ -387,7 +387,7 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 
 	p.AddResourceConfigurator("google_compute_region_disk_iam_member", func(r *config.Resource) {
 		r.References["name"] = config.Reference{
-			Type: "RegionDisk",
+			TerraformName: "google_compute_region_disk",
 		}
 	})
 
@@ -405,7 +405,7 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 
 	p.AddResourceConfigurator("google_compute_region_target_https_proxy", func(r *config.Resource) {
 		r.References["ssl_certificates"] = config.Reference{
-			Type: "RegionSSLCertificate",
+			TerraformName: "google_compute_region_ssl_certificate",
 		}
 		config.MarkAsRequired(r.TerraformResource, "region")
 	})
@@ -422,7 +422,7 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 
 	p.AddResourceConfigurator("google_compute_firewall_policy_association", func(r *config.Resource) {
 		r.References["ssl_certificates"] = config.Reference{
-			Type: "RegionSSLCertificate",
+			TerraformName: "google_compute_region_ssl_certificate",
 		}
 	})
 
@@ -436,54 +436,54 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 
 	p.AddResourceConfigurator("google_compute_target_ssl_proxy", func(r *config.Resource) {
 		r.References["ssl_certificates"] = config.Reference{
-			Type: "SSLCertificate",
+			TerraformName: "google_compute_ssl_certificate",
 		}
 	})
 
 	p.AddResourceConfigurator("google_compute_image_iam_member", func(r *config.Resource) {
 		r.References["image"] = config.Reference{
-			Type: "Image",
+			TerraformName: "google_compute_image",
 		}
 	})
 
 	p.AddResourceConfigurator("google_compute_vpn_tunnel", func(r *config.Resource) {
 		r.References["peer_external_gateway"] = config.Reference{
-			Type: "ExternalVPNGateway",
+			TerraformName: "google_compute_external_vpn_gateway",
 		}
 		r.References["router"] = config.Reference{
-			Type: "Router",
+			TerraformName: "google_compute_router",
 		}
 		r.References["vpn_gateway"] = config.Reference{
-			Type: "HaVPNGateway",
+			TerraformName: "google_compute_ha_vpn_gateway",
 		}
 		config.MarkAsRequired(r.TerraformResource, "region")
 	})
 
 	p.AddResourceConfigurator("google_compute_target_https_proxy", func(r *config.Resource) {
 		r.References["ssl_certificates"] = config.Reference{
-			Type: "SSLCertificate",
+			TerraformName: "google_compute_ssl_certificate",
 		}
 	})
 
 	p.AddResourceConfigurator("google_compute_service_attachment", func(r *config.Resource) {
 		r.References["nat_subnets"] = config.Reference{
-			Type: "Subnetwork",
+			TerraformName: "google_compute_subnetwork",
 		}
 		r.MarkAsRequired("region")
 	})
 
 	p.AddResourceConfigurator("google_compute_route", func(r *config.Resource) {
 		r.References["next_hop_vpn_tunnel"] = config.Reference{
-			Type: "VPNTunnel",
+			TerraformName: "google_compute_vpn_tunnel",
 		}
 	})
 
 	p.AddResourceConfigurator("google_compute_router_interface", func(r *config.Resource) {
 		r.References["router"] = config.Reference{
-			Type: "Router",
+			TerraformName: "google_compute_router",
 		}
 		r.References["vpn_tunnel"] = config.Reference{
-			Type: "VPNTunnel",
+			TerraformName: "google_compute_vpn_tunnel",
 		}
 	})
 
@@ -497,7 +497,7 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 
 	p.AddResourceConfigurator("google_compute_subnetwork_iam_member", func(r *config.Resource) {
 		r.References["subnetwork"] = config.Reference{
-			Type: "Subnetwork",
+			TerraformName: "google_compute_subnetwork",
 		}
 		config.MarkAsRequired(r.TerraformResource, "region")
 	})

--- a/config/container/config.go
+++ b/config/container/config.go
@@ -118,12 +118,12 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 			}, nil
 		}
 		r.References["network"] = config.Reference{
-			Type:      "github.com/upbound/provider-gcp/apis/compute/v1beta1.Network",
-			Extractor: common.PathSelfLinkExtractor,
+			TerraformName: "google_compute_network",
+			Extractor:     common.PathSelfLinkExtractor,
 		}
 		r.References["subnetwork"] = config.Reference{
-			Type:      "github.com/upbound/provider-gcp/apis/compute/v1beta1.Subnetwork",
-			Extractor: common.PathSelfLinkExtractor,
+			TerraformName: "google_compute_subnetwork",
+			Extractor:     common.PathSelfLinkExtractor,
 		}
 		r.ServerSideApplyMergeStrategies["node_config"] = config.MergeStrategy{
 			ListMergeStrategy: config.ListMergeStrategy{
@@ -147,8 +147,8 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 			},
 		}
 		r.References["cluster"] = config.Reference{
-			Type:      "Cluster",
-			Extractor: common.ExtractResourceIDFuncPath,
+			TerraformName: "google_container_cluster",
+			Extractor:     common.ExtractResourceIDFuncPath,
 		}
 
 		r.ServerSideApplyMergeStrategies["node_config"] = config.MergeStrategy{

--- a/config/containeraws/config.go
+++ b/config/containeraws/config.go
@@ -19,7 +19,7 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 		r.Kind = "NodePool"
 
 		r.References["cluster"] = config.Reference{
-			Type: "Cluster",
+			TerraformName: "google_container_aws_cluster",
 		}
 	})
 

--- a/config/containerazure/config.go
+++ b/config/containerazure/config.go
@@ -34,7 +34,7 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 		r.Kind = "NodePool"
 
 		r.References["cluster"] = config.Reference{
-			Type: "Cluster",
+			TerraformName: "google_container_azure_cluster",
 		}
 	})
 

--- a/config/dns/config.go
+++ b/config/dns/config.go
@@ -15,17 +15,17 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("google_dns_managed_zone", func(r *config.Resource) {
 		r.References["peering_config.target_network.network_url"] = config.Reference{
-			Type:      "github.com/upbound/provider-gcp/apis/compute/v1beta1.Network",
-			Extractor: common.PathSelfLinkExtractor,
+			TerraformName: "google_compute_network",
+			Extractor:     common.PathSelfLinkExtractor,
 		}
 		r.References["private_visibility_config.networks.network_url"] = config.Reference{
-			Type:      "github.com/upbound/provider-gcp/apis/compute/v1beta1.Network",
-			Extractor: common.PathSelfLinkExtractor,
+			TerraformName: "google_compute_network",
+			Extractor:     common.PathSelfLinkExtractor,
 		}
 	})
 	p.AddResourceConfigurator("google_dns_policy", func(r *config.Resource) {
 		r.References["networks.network_url"] = config.Reference{
-			Type:              "github.com/upbound/provider-gcp/apis/compute/v1beta1.Network",
+			TerraformName:     "google_compute_network",
 			RefFieldName:      "NetworkRef",
 			SelectorFieldName: "NetworkSelector",
 			Extractor:         common.ExtractResourceIDFuncPath,

--- a/config/firebaserules/config.go
+++ b/config/firebaserules/config.go
@@ -13,7 +13,7 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("google_firebaserules_release", func(r *config.Resource) {
 		r.References["ruleset_name"] = config.Reference{
-			Type: "Ruleset",
+			TerraformName: "google_firebaserules_ruleset",
 		}
 	})
 }

--- a/config/gameservices/config.go
+++ b/config/gameservices/config.go
@@ -13,7 +13,7 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("google_game_services_game_server_cluster", func(r *config.Resource) {
 		r.References["connection_info.gke_cluster_reference.cluster"] = config.Reference{
-			Type: "github.com/upbound/provider-gcp/apis/container/v1beta1.Cluster",
+			TerraformName: "google_container_cluster",
 		}
 	})
 }

--- a/config/gkehub/config.go
+++ b/config/gkehub/config.go
@@ -13,7 +13,7 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("google_gke_hub_membership_iam_member", func(r *config.Resource) {
 		r.References["membership_id"] = config.Reference{
-			Type: "github.com/upbound/provider-gcp/apis/gkehub/v1beta1.Membership",
+			TerraformName: "google_gke_hub_membership",
 		}
 	})
 }

--- a/config/healthcare/config.go
+++ b/config/healthcare/config.go
@@ -13,7 +13,7 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("google_healthcare_dataset_iam_member", func(r *config.Resource) {
 		r.References["dataset_id"] = config.Reference{
-			Type: "github.com/upbound/provider-gcp/apis/healthcare/v1beta1.Dataset",
+			TerraformName: "google_healthcare_dataset",
 		}
 	})
 }

--- a/config/iap/config.go
+++ b/config/iap/config.go
@@ -13,13 +13,13 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("google_iap_web_backend_service_iam_member", func(r *config.Resource) {
 		r.References["web_backend_service"] = config.Reference{
-			Type: "github.com/upbound/provider-gcp/apis/compute/v1beta1.BackendService",
+			TerraformName: "google_compute_backend_service",
 		}
 	})
 
 	p.AddResourceConfigurator("google_iap_web_type_app_engine_iam_member", func(r *config.Resource) {
 		r.References["app_id"] = config.Reference{
-			Type: "github.com/upbound/provider-gcp/apis/appengine/v1beta1.Application",
+			TerraformName: "google_app_engine_application",
 		}
 	})
 }

--- a/config/kms/config.go
+++ b/config/kms/config.go
@@ -16,22 +16,22 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("google_kms_crypto_key_iam_member", func(r *config.Resource) {
 		r.References["crypto_key_id"] = config.Reference{
-			Type:      "CryptoKey",
-			Extractor: common.ExtractResourceIDFuncPath,
+			TerraformName: "google_kms_crypto_key",
+			Extractor:     common.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("google_kms_key_ring_iam_member", func(r *config.Resource) {
 		r.References["key_ring_id"] = config.Reference{
-			Type:      "KeyRing",
-			Extractor: common.ExtractResourceIDFuncPath,
+			TerraformName: "google_kms_key_ring",
+			Extractor:     common.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("google_kms_key_ring_import_job", func(r *config.Resource) {
 		r.References["key_ring"] = config.Reference{
-			Type:      "KeyRing",
-			Extractor: common.ExtractResourceIDFuncPath,
+			TerraformName: "google_kms_key_ring",
+			Extractor:     common.ExtractResourceIDFuncPath,
 		}
 		config.MoveToStatus(r.TerraformResource, "public_key")
 	})

--- a/config/logging/config.go
+++ b/config/logging/config.go
@@ -15,8 +15,8 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("google_logging_folder_bucket_config", func(r *config.Resource) {
 		r.References["folder"] = config.Reference{
-			Type:      "github.com/upbound/provider-gcp/apis/cloudplatform/v1beta1.Folder",
-			Extractor: common.ExtractFolderIDFuncPath,
+			TerraformName: "google_folder",
+			Extractor:     common.ExtractFolderIDFuncPath,
 		}
 	})
 }

--- a/config/notebooks/config.go
+++ b/config/notebooks/config.go
@@ -15,7 +15,7 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("google_notebooks_instance_iam_member", func(r *config.Resource) {
 		r.References["instance_name"] = config.Reference{
-			Type: "Instance",
+			TerraformName: "google_notebooks_instance",
 		}
 	})
 
@@ -26,7 +26,7 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("google_notebooks_runtime_iam_member", func(r *config.Resource) {
 		r.References["runtime_name"] = config.Reference{
-			Type: "Runtime",
+			TerraformName: "google_notebooks_runtime",
 		}
 	})
 	p.AddResourceConfigurator("google_notebooks_runtime", func(r *config.Resource) {

--- a/config/privateca/config.go
+++ b/config/privateca/config.go
@@ -16,27 +16,27 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("google_privateca_ca_pool_iam_member", func(r *config.Resource) {
 		r.References["ca_pool"] = config.Reference{
-			Type:      "CAPool",
-			Extractor: common.ExtractResourceIDFuncPath,
+			TerraformName: "google_privateca_ca_pool",
+			Extractor:     common.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("google_privateca_certificate_template_iam_member", func(r *config.Resource) {
 		r.References["certificate_template"] = config.Reference{
-			Type:      "CertificateTemplate",
-			Extractor: common.ExtractResourceIDFuncPath,
+			TerraformName: "google_privateca_certificate_template",
+			Extractor:     common.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("google_privateca_certificate_authority", func(r *config.Resource) {
 		r.References["pool"] = config.Reference{
-			Type: "CAPool",
+			TerraformName: "google_privateca_ca_pool",
 		}
 	})
 
 	p.AddResourceConfigurator("google_privateca_certificate", func(r *config.Resource) {
 		r.References["pool"] = config.Reference{
-			Type: "CAPool",
+			TerraformName: "google_privateca_ca_pool",
 		}
 		r.TerraformResource.Schema["config"].Elem.(*schema.Resource).
 			Schema["public_key"].Elem.(*schema.Resource).

--- a/config/pubsub/config.go
+++ b/config/pubsub/config.go
@@ -15,7 +15,7 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("google_pubsub_lite_subscription", func(r *config.Resource) {
 		r.References["topic"] = config.Reference{
-			Type: "LiteTopic",
+			TerraformName: "google_pubsub_lite_topic",
 		}
 		r.Sensitive.AdditionalConnectionDetailsFn = pubsubLiteConnectionDetails
 		config.MarkAsRequired(r.TerraformResource, "zone")
@@ -23,7 +23,7 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("google_pubsub_lite_topic", func(r *config.Resource) {
 		r.References["reservation_config.throughput_reservation"] = config.Reference{
-			Type: "LiteReservation",
+			TerraformName: "google_pubsub_lite_reservation",
 		}
 		r.Sensitive.AdditionalConnectionDetailsFn = pubsubLiteConnectionDetails
 		config.MarkAsRequired(r.TerraformResource, "zone")
@@ -32,7 +32,7 @@ func Configure(p *config.Provider) {
 	})
 	p.AddResourceConfigurator("google_pubsub_subscription", func(r *config.Resource) {
 		r.References["topic"] = config.Reference{
-			Type: "Topic",
+			TerraformName: "google_pubsub_topic",
 		}
 		r.Sensitive.AdditionalConnectionDetailsFn = pubsubConnectionDetails
 		delete(r.References, "cloud_storage_config.bucket")
@@ -40,7 +40,7 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("google_pubsub_subscription_iam_member", func(r *config.Resource) {
 		r.References["subscription"] = config.Reference{
-			Type: "Subscription",
+			TerraformName: "google_pubsub_subscription",
 		}
 	})
 
@@ -50,7 +50,7 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("google_pubsub_topic_iam_member", func(r *config.Resource) {
 		r.References["topic"] = config.Reference{
-			Type: "Topic",
+			TerraformName: "google_pubsub_topic",
 		}
 	})
 }

--- a/config/secretmanager/config.go
+++ b/config/secretmanager/config.go
@@ -18,15 +18,15 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("google_secret_manager_secret_iam_member", func(r *config.Resource) {
 		r.References["secret_id"] = config.Reference{
-			Type:      "Secret",
-			Extractor: common.ExtractResourceIDFuncPath,
+			TerraformName: "google_secret_manager_secret",
+			Extractor:     common.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("google_secret_manager_secret_version", func(r *config.Resource) {
 		r.References["secret"] = config.Reference{
-			Type:      "Secret",
-			Extractor: common.ExtractResourceIDFuncPath,
+			TerraformName: "google_secret_manager_secret",
+			Extractor:     common.ExtractResourceIDFuncPath,
 		}
 		r.MetaResource.ArgumentDocs["secret_data"] = `The secret data. Must be no larger than 64KiB.`
 	})

--- a/config/servicenetworking/config.go
+++ b/config/servicenetworking/config.go
@@ -14,7 +14,7 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("google_service_networking_connection", func(r *config.Resource) {
 		// Note(donovanmuller): Upjet does not add this reference automatically
 		r.References["reserved_peering_ranges"] = config.Reference{
-			Type: "github.com/upbound/provider-gcp/apis/compute/v1beta1.GlobalAddress",
+			TerraformName: "google_compute_global_address",
 		}
 	})
 }

--- a/config/sourcerepo/config.go
+++ b/config/sourcerepo/config.go
@@ -15,7 +15,7 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("google_sourcerepo_repository_iam_member", func(r *config.Resource) {
 		// The reference should be manually inferred, but this is not yet activated for GCP
 		r.References["repository"] = config.Reference{
-			Type: "Repository",
+			TerraformName: "google_sourcerepo_repository",
 		}
 	})
 

--- a/config/spanner/config.go
+++ b/config/spanner/config.go
@@ -25,8 +25,8 @@ func Configure(p *config.Provider) {
 	// The congiguration works only by using instance: name directly
 	p.AddResourceConfigurator("google_spanner_instance_iam_member", func(r *config.Resource) {
 		r.References["instance"] = config.Reference{
-			Type:      "Instance",
-			Extractor: common.ExtractResourceIDFuncPath,
+			TerraformName: "google_spanner_instance",
+			Extractor:     common.ExtractResourceIDFuncPath,
 		}
 	})
 
@@ -34,8 +34,8 @@ func Configure(p *config.Provider) {
 	// The congiguration works only by using instance: name directly
 	p.AddResourceConfigurator("google_spanner_database_iam_member", func(r *config.Resource) {
 		r.References["instance"] = config.Reference{
-			Type:      "Instance",
-			Extractor: common.ExtractResourceIDFuncPath,
+			TerraformName: "google_spanner_instance",
+			Extractor:     common.ExtractResourceIDFuncPath,
 		}
 	})
 
@@ -43,8 +43,8 @@ func Configure(p *config.Provider) {
 	// The congiguration works only by using database: name directly
 	p.AddResourceConfigurator("google_spanner_database_iam_member", func(r *config.Resource) {
 		r.References["database"] = config.Reference{
-			Type:      "Database",
-			Extractor: common.ExtractResourceIDFuncPath,
+			TerraformName: "google_spanner_database",
+			Extractor:     common.ExtractResourceIDFuncPath,
 		}
 	})
 

--- a/config/sql/config.go
+++ b/config/sql/config.go
@@ -83,12 +83,12 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 	})
 	p.AddResourceConfigurator("google_sql_database", func(r *config.Resource) {
 		r.References["instance"] = config.Reference{
-			Type: "DatabaseInstance",
+			TerraformName: "google_sql_database_instance",
 		}
 	})
 	p.AddResourceConfigurator("google_sql_source_representation_instance", func(r *config.Resource) {
 		r.References["instance"] = config.Reference{
-			Type: "DatabaseInstance",
+			TerraformName: "google_sql_database_instance",
 		}
 	})
 	p.AddResourceConfigurator("google_sql_user", func(r *config.Resource) {
@@ -115,7 +115,7 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 		}
 
 		r.References["instance"] = config.Reference{
-			Type: "DatabaseInstance",
+			TerraformName: "google_sql_database_instance",
 		}
 
 		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]any) (map[string][]byte, error) {
@@ -128,7 +128,7 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 	})
 	p.AddResourceConfigurator("google_sql_ssl_cert", func(r *config.Resource) {
 		r.References["instance"] = config.Reference{
-			Type: "DatabaseInstance",
+			TerraformName: "google_sql_database_instance",
 		}
 	})
 }

--- a/config/storage/config.go
+++ b/config/storage/config.go
@@ -33,14 +33,14 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("google_storage_bucket_iam_member", func(r *config.Resource) {
 		r.References["bucket"] = config.Reference{
-			Type: "Bucket",
+			TerraformName: "google_storage_bucket",
 		}
 	})
 
 	p.AddResourceConfigurator("google_storage_bucket_object", func(r *config.Resource) {
 		r.TerraformResource.Schema["content"].Sensitive = false
 		r.References["bucket"] = config.Reference{
-			Type: "Bucket",
+			TerraformName: "google_storage_bucket",
 		}
 	})
 }

--- a/config/vpcaccess/config.go
+++ b/config/vpcaccess/config.go
@@ -11,7 +11,7 @@ import "github.com/crossplane/upjet/pkg/config"
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("google_vpc_access_connector", func(r *config.Resource) {
 		r.References["network"] = config.Reference{
-			Type: "github.com/upbound/provider-gcp/apis/compute/v1beta1.Network",
+			TerraformName: "google_compute_network",
 		}
 		config.MarkAsRequired(r.TerraformResource, "region")
 	})

--- a/package/crds/accesscontextmanager.gcp.upbound.io_serviceperimeters.yaml
+++ b/package/crds/accesscontextmanager.gcp.upbound.io_serviceperimeters.yaml
@@ -134,7 +134,8 @@ spec:
                           type: array
                           x-kubernetes-list-type: set
                         accessLevelsRefs:
-                          description: References to AccessLevel to populate accessLevels.
+                          description: References to AccessLevel in accesscontextmanager
+                            to populate accessLevels.
                           items:
                             description: A Reference to a named object.
                             properties:
@@ -171,8 +172,8 @@ spec:
                             type: object
                           type: array
                         accessLevelsSelector:
-                          description: Selector for a list of AccessLevel to populate
-                            accessLevels.
+                          description: Selector for a list of AccessLevel in accesscontextmanager
+                            to populate accessLevels.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -521,7 +522,8 @@ spec:
                           type: array
                           x-kubernetes-list-type: set
                         accessLevelsRefs:
-                          description: References to AccessLevel to populate accessLevels.
+                          description: References to AccessLevel in accesscontextmanager
+                            to populate accessLevels.
                           items:
                             description: A Reference to a named object.
                             properties:
@@ -558,8 +560,8 @@ spec:
                             type: object
                           type: array
                         accessLevelsSelector:
-                          description: Selector for a list of AccessLevel to populate
-                            accessLevels.
+                          description: Selector for a list of AccessLevel in accesscontextmanager
+                            to populate accessLevels.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -1052,7 +1054,8 @@ spec:
                           type: array
                           x-kubernetes-list-type: set
                         accessLevelsRefs:
-                          description: References to AccessLevel to populate accessLevels.
+                          description: References to AccessLevel in accesscontextmanager
+                            to populate accessLevels.
                           items:
                             description: A Reference to a named object.
                             properties:
@@ -1089,8 +1092,8 @@ spec:
                             type: object
                           type: array
                         accessLevelsSelector:
-                          description: Selector for a list of AccessLevel to populate
-                            accessLevels.
+                          description: Selector for a list of AccessLevel in accesscontextmanager
+                            to populate accessLevels.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -1439,7 +1442,8 @@ spec:
                           type: array
                           x-kubernetes-list-type: set
                         accessLevelsRefs:
-                          description: References to AccessLevel to populate accessLevels.
+                          description: References to AccessLevel in accesscontextmanager
+                            to populate accessLevels.
                           items:
                             description: A Reference to a named object.
                             properties:
@@ -1476,8 +1480,8 @@ spec:
                             type: object
                           type: array
                         accessLevelsSelector:
-                          description: Selector for a list of AccessLevel to populate
-                            accessLevels.
+                          description: Selector for a list of AccessLevel in accesscontextmanager
+                            to populate accessLevels.
                           properties:
                             matchControllerRef:
                               description: |-

--- a/package/crds/cloudfunctions.gcp.upbound.io_functioniammembers.yaml
+++ b/package/crds/cloudfunctions.gcp.upbound.io_functioniammembers.yaml
@@ -76,7 +76,8 @@ spec:
                   cloudFunction:
                     type: string
                   cloudFunctionRef:
-                    description: Reference to a Function to populate cloudFunction.
+                    description: Reference to a Function in cloudfunctions to populate
+                      cloudFunction.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -110,7 +111,8 @@ spec:
                     - name
                     type: object
                   cloudFunctionSelector:
-                    description: Selector for a Function to populate cloudFunction.
+                    description: Selector for a Function in cloudfunctions to populate
+                      cloudFunction.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -185,7 +187,8 @@ spec:
                   cloudFunction:
                     type: string
                   cloudFunctionRef:
-                    description: Reference to a Function to populate cloudFunction.
+                    description: Reference to a Function in cloudfunctions to populate
+                      cloudFunction.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -219,7 +222,8 @@ spec:
                     - name
                     type: object
                   cloudFunctionSelector:
-                    description: Selector for a Function to populate cloudFunction.
+                    description: Selector for a Function in cloudfunctions to populate
+                      cloudFunction.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/cloudplatform.gcp.upbound.io_folderiammembers.yaml
+++ b/package/crds/cloudplatform.gcp.upbound.io_folderiammembers.yaml
@@ -87,7 +87,8 @@ spec:
                   folder:
                     type: string
                   folderRef:
-                    description: Reference to a Folder to populate folder.
+                    description: Reference to a Folder in cloudplatform to populate
+                      folder.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -121,7 +122,8 @@ spec:
                     - name
                     type: object
                   folderSelector:
-                    description: Selector for a Folder to populate folder.
+                    description: Selector for a Folder in cloudplatform to populate
+                      folder.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -192,7 +194,8 @@ spec:
                   folder:
                     type: string
                   folderRef:
-                    description: Reference to a Folder to populate folder.
+                    description: Reference to a Folder in cloudplatform to populate
+                      folder.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -226,7 +229,8 @@ spec:
                     - name
                     type: object
                   folderSelector:
-                    description: Selector for a Folder to populate folder.
+                    description: Selector for a Folder in cloudplatform to populate
+                      folder.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/cloudplatform.gcp.upbound.io_projectdefaultserviceaccounts.yaml
+++ b/package/crds/cloudplatform.gcp.upbound.io_projectdefaultserviceaccounts.yaml
@@ -85,7 +85,8 @@ spec:
                     description: The project ID where service accounts are created.
                     type: string
                   projectRef:
-                    description: Reference to a Project to populate project.
+                    description: Reference to a Project in cloudplatform to populate
+                      project.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -119,7 +120,8 @@ spec:
                     - name
                     type: object
                   projectSelector:
-                    description: Selector for a Project to populate project.
+                    description: Selector for a Project in cloudplatform to populate
+                      project.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -189,7 +191,8 @@ spec:
                     description: The project ID where service accounts are created.
                     type: string
                   projectRef:
-                    description: Reference to a Project to populate project.
+                    description: Reference to a Project in cloudplatform to populate
+                      project.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -223,7 +226,8 @@ spec:
                     - name
                     type: object
                   projectSelector:
-                    description: Selector for a Project to populate project.
+                    description: Selector for a Project in cloudplatform to populate
+                      project.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/cloudplatform.gcp.upbound.io_projectiamauditconfigs.yaml
+++ b/package/crds/cloudplatform.gcp.upbound.io_projectiamauditconfigs.yaml
@@ -88,7 +88,8 @@ spec:
                   project:
                     type: string
                   projectRef:
-                    description: Reference to a Project to populate project.
+                    description: Reference to a Project in cloudplatform to populate
+                      project.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -122,7 +123,8 @@ spec:
                     - name
                     type: object
                   projectSelector:
-                    description: Selector for a Project to populate project.
+                    description: Selector for a Project in cloudplatform to populate
+                      project.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -192,7 +194,8 @@ spec:
                   project:
                     type: string
                   projectRef:
-                    description: Reference to a Project to populate project.
+                    description: Reference to a Project in cloudplatform to populate
+                      project.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -226,7 +229,8 @@ spec:
                     - name
                     type: object
                   projectSelector:
-                    description: Selector for a Project to populate project.
+                    description: Selector for a Project in cloudplatform to populate
+                      project.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/cloudplatform.gcp.upbound.io_projectiammembers.yaml
+++ b/package/crds/cloudplatform.gcp.upbound.io_projectiammembers.yaml
@@ -89,7 +89,8 @@ spec:
                   project:
                     type: string
                   projectRef:
-                    description: Reference to a Project to populate project.
+                    description: Reference to a Project in cloudplatform to populate
+                      project.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -123,7 +124,8 @@ spec:
                     - name
                     type: object
                   projectSelector:
-                    description: Selector for a Project to populate project.
+                    description: Selector for a Project in cloudplatform to populate
+                      project.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -194,7 +196,8 @@ spec:
                   project:
                     type: string
                   projectRef:
-                    description: Reference to a Project to populate project.
+                    description: Reference to a Project in cloudplatform to populate
+                      project.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -228,7 +231,8 @@ spec:
                     - name
                     type: object
                   projectSelector:
-                    description: Selector for a Project to populate project.
+                    description: Selector for a Project in cloudplatform to populate
+                      project.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/cloudplatform.gcp.upbound.io_projectservices.yaml
+++ b/package/crds/cloudplatform.gcp.upbound.io_projectservices.yaml
@@ -92,7 +92,8 @@ spec:
                       is used.
                     type: string
                   projectRef:
-                    description: Reference to a Project to populate project.
+                    description: Reference to a Project in cloudplatform to populate
+                      project.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -126,7 +127,8 @@ spec:
                     - name
                     type: object
                   projectSelector:
-                    description: Selector for a Project to populate project.
+                    description: Selector for a Project in cloudplatform to populate
+                      project.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -201,7 +203,8 @@ spec:
                       is used.
                     type: string
                   projectRef:
-                    description: Reference to a Project to populate project.
+                    description: Reference to a Project in cloudplatform to populate
+                      project.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -235,7 +238,8 @@ spec:
                     - name
                     type: object
                   projectSelector:
-                    description: Selector for a Project to populate project.
+                    description: Selector for a Project in cloudplatform to populate
+                      project.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/cloudplatform.gcp.upbound.io_projectusageexportbuckets.yaml
+++ b/package/crds/cloudplatform.gcp.upbound.io_projectusageexportbuckets.yaml
@@ -160,7 +160,8 @@ spec:
                       is not provided, the provider project is used.'
                     type: string
                   projectRef:
-                    description: Reference to a Project to populate project.
+                    description: Reference to a Project in cloudplatform to populate
+                      project.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -194,7 +195,8 @@ spec:
                     - name
                     type: object
                   projectSelector:
-                    description: Selector for a Project to populate project.
+                    description: Selector for a Project in cloudplatform to populate
+                      project.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -333,7 +335,8 @@ spec:
                       is not provided, the provider project is used.'
                     type: string
                   projectRef:
-                    description: Reference to a Project to populate project.
+                    description: Reference to a Project in cloudplatform to populate
+                      project.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -367,7 +370,8 @@ spec:
                     - name
                     type: object
                   projectSelector:
-                    description: Selector for a Project to populate project.
+                    description: Selector for a Project in cloudplatform to populate
+                      project.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/cloudplatform.gcp.upbound.io_serviceaccountiammembers.yaml
+++ b/package/crds/cloudplatform.gcp.upbound.io_serviceaccountiammembers.yaml
@@ -92,7 +92,8 @@ spec:
                   serviceAccountId:
                     type: string
                   serviceAccountIdRef:
-                    description: Reference to a ServiceAccount to populate serviceAccountId.
+                    description: Reference to a ServiceAccount in cloudplatform to
+                      populate serviceAccountId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -126,7 +127,8 @@ spec:
                     - name
                     type: object
                   serviceAccountIdSelector:
-                    description: Selector for a ServiceAccount to populate serviceAccountId.
+                    description: Selector for a ServiceAccount in cloudplatform to
+                      populate serviceAccountId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -197,7 +199,8 @@ spec:
                   serviceAccountId:
                     type: string
                   serviceAccountIdRef:
-                    description: Reference to a ServiceAccount to populate serviceAccountId.
+                    description: Reference to a ServiceAccount in cloudplatform to
+                      populate serviceAccountId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -231,7 +234,8 @@ spec:
                     - name
                     type: object
                   serviceAccountIdSelector:
-                    description: Selector for a ServiceAccount to populate serviceAccountId.
+                    description: Selector for a ServiceAccount in cloudplatform to
+                      populate serviceAccountId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/cloudplatform.gcp.upbound.io_serviceaccountkeys.yaml
+++ b/package/crds/cloudplatform.gcp.upbound.io_serviceaccountkeys.yaml
@@ -110,7 +110,8 @@ spec:
                       unique id. Substituting - as a wildcard for the {PROJECT_ID} will infer the project from the account.
                     type: string
                   serviceAccountIdRef:
-                    description: Reference to a ServiceAccount to populate serviceAccountId.
+                    description: Reference to a ServiceAccount in cloudplatform to
+                      populate serviceAccountId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -144,7 +145,8 @@ spec:
                     - name
                     type: object
                   serviceAccountIdSelector:
-                    description: Selector for a ServiceAccount to populate serviceAccountId.
+                    description: Selector for a ServiceAccount in cloudplatform to
+                      populate serviceAccountId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -234,7 +236,8 @@ spec:
                       unique id. Substituting - as a wildcard for the {PROJECT_ID} will infer the project from the account.
                     type: string
                   serviceAccountIdRef:
-                    description: Reference to a ServiceAccount to populate serviceAccountId.
+                    description: Reference to a ServiceAccount in cloudplatform to
+                      populate serviceAccountId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -268,7 +271,8 @@ spec:
                     - name
                     type: object
                   serviceAccountIdSelector:
-                    description: Selector for a ServiceAccount to populate serviceAccountId.
+                    description: Selector for a ServiceAccount in cloudplatform to
+                      populate serviceAccountId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/cloudrun.gcp.upbound.io_domainmappings.yaml
+++ b/package/crds/cloudrun.gcp.upbound.io_domainmappings.yaml
@@ -222,7 +222,8 @@ spec:
                             The route must exist.
                           type: string
                         routeNameRef:
-                          description: Reference to a Service to populate routeName.
+                          description: Reference to a Service in cloudrun to populate
+                            routeName.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -256,7 +257,8 @@ spec:
                           - name
                           type: object
                         routeNameSelector:
-                          description: Selector for a Service to populate routeName.
+                          description: Selector for a Service in cloudrun to populate
+                            routeName.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -460,7 +462,8 @@ spec:
                             The route must exist.
                           type: string
                         routeNameRef:
-                          description: Reference to a Service to populate routeName.
+                          description: Reference to a Service in cloudrun to populate
+                            routeName.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -494,7 +497,8 @@ spec:
                           - name
                           type: object
                         routeNameSelector:
-                          description: Selector for a Service to populate routeName.
+                          description: Selector for a Service in cloudrun to populate
+                            routeName.
                           properties:
                             matchControllerRef:
                               description: |-

--- a/package/crds/cloudrun.gcp.upbound.io_serviceiammembers.yaml
+++ b/package/crds/cloudrun.gcp.upbound.io_serviceiammembers.yaml
@@ -171,7 +171,7 @@ spec:
                   service:
                     type: string
                   serviceRef:
-                    description: Reference to a Service to populate service.
+                    description: Reference to a Service in cloudrun to populate service.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -205,7 +205,7 @@ spec:
                     - name
                     type: object
                   serviceSelector:
-                    description: Selector for a Service to populate service.
+                    description: Selector for a Service in cloudrun to populate service.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -356,7 +356,7 @@ spec:
                   service:
                     type: string
                   serviceRef:
-                    description: Reference to a Service to populate service.
+                    description: Reference to a Service in cloudrun to populate service.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -390,7 +390,7 @@ spec:
                     - name
                     type: object
                   serviceSelector:
-                    description: Selector for a Service to populate service.
+                    description: Selector for a Service in cloudrun to populate service.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/compute.gcp.upbound.io_addresses.yaml
+++ b/package/crds/compute.gcp.upbound.io_addresses.yaml
@@ -115,7 +115,7 @@ spec:
                       IPSEC_INTERCONNECT purposes.
                     type: string
                   networkRef:
-                    description: Reference to a Network to populate network.
+                    description: Reference to a Network in compute to populate network.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -149,7 +149,7 @@ spec:
                     - name
                     type: object
                   networkSelector:
-                    description: Selector for a Network to populate network.
+                    description: Selector for a Network in compute to populate network.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -221,7 +221,8 @@ spec:
                       GCE_ENDPOINT/DNS_RESOLVER purposes.
                     type: string
                   subnetworkRef:
-                    description: Reference to a Subnetwork to populate subnetwork.
+                    description: Reference to a Subnetwork in compute to populate
+                      subnetwork.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -255,7 +256,8 @@ spec:
                     - name
                     type: object
                   subnetworkSelector:
-                    description: Selector for a Subnetwork to populate subnetwork.
+                    description: Selector for a Subnetwork in compute to populate
+                      subnetwork.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -352,7 +354,7 @@ spec:
                       IPSEC_INTERCONNECT purposes.
                     type: string
                   networkRef:
-                    description: Reference to a Network to populate network.
+                    description: Reference to a Network in compute to populate network.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -386,7 +388,7 @@ spec:
                     - name
                     type: object
                   networkSelector:
-                    description: Selector for a Network to populate network.
+                    description: Selector for a Network in compute to populate network.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -453,7 +455,8 @@ spec:
                       GCE_ENDPOINT/DNS_RESOLVER purposes.
                     type: string
                   subnetworkRef:
-                    description: Reference to a Subnetwork to populate subnetwork.
+                    description: Reference to a Subnetwork in compute to populate
+                      subnetwork.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -487,7 +490,8 @@ spec:
                     - name
                     type: object
                   subnetworkSelector:
-                    description: Selector for a Subnetwork to populate subnetwork.
+                    description: Selector for a Subnetwork in compute to populate
+                      subnetwork.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/compute.gcp.upbound.io_backendservices.yaml
+++ b/package/crds/compute.gcp.upbound.io_backendservices.yaml
@@ -131,8 +131,8 @@ spec:
                             partial URL.
                           type: string
                         groupRef:
-                          description: Reference to a InstanceGroupManager to populate
-                            group.
+                          description: Reference to a InstanceGroupManager in compute
+                            to populate group.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -166,8 +166,8 @@ spec:
                           - name
                           type: object
                         groupSelector:
-                          description: Selector for a InstanceGroupManager to populate
-                            group.
+                          description: Selector for a InstanceGroupManager in compute
+                            to populate group.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -561,7 +561,8 @@ spec:
                     type: array
                     x-kubernetes-list-type: set
                   healthChecksRefs:
-                    description: References to HealthCheck to populate healthChecks.
+                    description: References to HealthCheck in compute to populate
+                      healthChecks.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -598,7 +599,8 @@ spec:
                       type: object
                     type: array
                   healthChecksSelector:
-                    description: Selector for a list of HealthCheck to populate healthChecks.
+                    description: Selector for a list of HealthCheck in compute to
+                      populate healthChecks.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -1003,8 +1005,8 @@ spec:
                             partial URL.
                           type: string
                         groupRef:
-                          description: Reference to a InstanceGroupManager to populate
-                            group.
+                          description: Reference to a InstanceGroupManager in compute
+                            to populate group.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -1038,8 +1040,8 @@ spec:
                           - name
                           type: object
                         groupSelector:
-                          description: Selector for a InstanceGroupManager to populate
-                            group.
+                          description: Selector for a InstanceGroupManager in compute
+                            to populate group.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -1433,7 +1435,8 @@ spec:
                     type: array
                     x-kubernetes-list-type: set
                   healthChecksRefs:
-                    description: References to HealthCheck to populate healthChecks.
+                    description: References to HealthCheck in compute to populate
+                      healthChecks.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -1470,7 +1473,8 @@ spec:
                       type: object
                     type: array
                   healthChecksSelector:
-                    description: Selector for a list of HealthCheck to populate healthChecks.
+                    description: Selector for a list of HealthCheck in compute to
+                      populate healthChecks.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/compute.gcp.upbound.io_diskiammembers.yaml
+++ b/package/crds/compute.gcp.upbound.io_diskiammembers.yaml
@@ -88,7 +88,7 @@ spec:
                   name:
                     type: string
                   nameRef:
-                    description: Reference to a Disk to populate name.
+                    description: Reference to a Disk in compute to populate name.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -122,7 +122,7 @@ spec:
                     - name
                     type: object
                   nameSelector:
-                    description: Selector for a Disk to populate name.
+                    description: Selector for a Disk in compute to populate name.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -197,7 +197,7 @@ spec:
                   name:
                     type: string
                   nameRef:
-                    description: Reference to a Disk to populate name.
+                    description: Reference to a Disk in compute to populate name.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -231,7 +231,7 @@ spec:
                     - name
                     type: object
                   nameSelector:
-                    description: Selector for a Disk to populate name.
+                    description: Selector for a Disk in compute to populate name.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/compute.gcp.upbound.io_firewalls.yaml
+++ b/package/crds/compute.gcp.upbound.io_firewalls.yaml
@@ -180,7 +180,7 @@ spec:
                       firewall to.
                     type: string
                   networkRef:
-                    description: Reference to a Network to populate network.
+                    description: Reference to a Network in compute to populate network.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -214,7 +214,7 @@ spec:
                     - name
                     type: object
                   networkSelector:
-                    description: Selector for a Network to populate network.
+                    description: Selector for a Network in compute to populate network.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -459,7 +459,7 @@ spec:
                       firewall to.
                     type: string
                   networkRef:
-                    description: Reference to a Network to populate network.
+                    description: Reference to a Network in compute to populate network.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -493,7 +493,7 @@ spec:
                     - name
                     type: object
                   networkSelector:
-                    description: Selector for a Network to populate network.
+                    description: Selector for a Network in compute to populate network.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/compute.gcp.upbound.io_forwardingrules.yaml
+++ b/package/crds/compute.gcp.upbound.io_forwardingrules.yaml
@@ -101,7 +101,8 @@ spec:
                       must be omitted for all other load balancer types.
                     type: string
                   backendServiceRef:
-                    description: Reference to a RegionBackendService to populate backendService.
+                    description: Reference to a RegionBackendService in compute to
+                      populate backendService.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -135,7 +136,8 @@ spec:
                     - name
                     type: object
                   backendServiceSelector:
-                    description: Selector for a RegionBackendService to populate backendService.
+                    description: Selector for a RegionBackendService in compute to
+                      populate backendService.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -188,7 +190,7 @@ spec:
                       required under the following circumstances:
                     type: string
                   ipAddressRef:
-                    description: Reference to a Address to populate ipAddress.
+                    description: Reference to a Address in compute to populate ipAddress.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -222,7 +224,7 @@ spec:
                     - name
                     type: object
                   ipAddressSelector:
-                    description: Selector for a Address to populate ipAddress.
+                    description: Selector for a Address in compute to populate ipAddress.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -319,7 +321,7 @@ spec:
                       APIs, a network must be provided.
                     type: string
                   networkRef:
-                    description: Reference to a Network to populate network.
+                    description: Reference to a Network in compute to populate network.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -353,7 +355,7 @@ spec:
                     - name
                     type: object
                   networkSelector:
-                    description: Selector for a Network to populate network.
+                    description: Selector for a Network in compute to populate network.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -492,7 +494,8 @@ spec:
                       mode or when creating external forwarding rule with IPv6.
                     type: string
                   subnetworkRef:
-                    description: Reference to a Subnetwork to populate subnetwork.
+                    description: Reference to a Subnetwork in compute to populate
+                      subnetwork.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -526,7 +529,8 @@ spec:
                     - name
                     type: object
                   subnetworkSelector:
-                    description: Selector for a Subnetwork to populate subnetwork.
+                    description: Selector for a Subnetwork in compute to populate
+                      subnetwork.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -572,8 +576,8 @@ spec:
                       IPAddress should be set to 0.0.0.0.
                     type: string
                   targetRef:
-                    description: Reference to a RegionTargetHTTPProxy to populate
-                      target.
+                    description: Reference to a RegionTargetHTTPProxy in compute to
+                      populate target.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -607,8 +611,8 @@ spec:
                     - name
                     type: object
                   targetSelector:
-                    description: Selector for a RegionTargetHTTPProxy to populate
-                      target.
+                    description: Selector for a RegionTargetHTTPProxy in compute to
+                      populate target.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -691,7 +695,8 @@ spec:
                       must be omitted for all other load balancer types.
                     type: string
                   backendServiceRef:
-                    description: Reference to a RegionBackendService to populate backendService.
+                    description: Reference to a RegionBackendService in compute to
+                      populate backendService.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -725,7 +730,8 @@ spec:
                     - name
                     type: object
                   backendServiceSelector:
-                    description: Selector for a RegionBackendService to populate backendService.
+                    description: Selector for a RegionBackendService in compute to
+                      populate backendService.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -778,7 +784,7 @@ spec:
                       required under the following circumstances:
                     type: string
                   ipAddressRef:
-                    description: Reference to a Address to populate ipAddress.
+                    description: Reference to a Address in compute to populate ipAddress.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -812,7 +818,7 @@ spec:
                     - name
                     type: object
                   ipAddressSelector:
-                    description: Selector for a Address to populate ipAddress.
+                    description: Selector for a Address in compute to populate ipAddress.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -909,7 +915,7 @@ spec:
                       APIs, a network must be provided.
                     type: string
                   networkRef:
-                    description: Reference to a Network to populate network.
+                    description: Reference to a Network in compute to populate network.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -943,7 +949,7 @@ spec:
                     - name
                     type: object
                   networkSelector:
-                    description: Selector for a Network to populate network.
+                    description: Selector for a Network in compute to populate network.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -1077,7 +1083,8 @@ spec:
                       mode or when creating external forwarding rule with IPv6.
                     type: string
                   subnetworkRef:
-                    description: Reference to a Subnetwork to populate subnetwork.
+                    description: Reference to a Subnetwork in compute to populate
+                      subnetwork.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -1111,7 +1118,8 @@ spec:
                     - name
                     type: object
                   subnetworkSelector:
-                    description: Selector for a Subnetwork to populate subnetwork.
+                    description: Selector for a Subnetwork in compute to populate
+                      subnetwork.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -1157,8 +1165,8 @@ spec:
                       IPAddress should be set to 0.0.0.0.
                     type: string
                   targetRef:
-                    description: Reference to a RegionTargetHTTPProxy to populate
-                      target.
+                    description: Reference to a RegionTargetHTTPProxy in compute to
+                      populate target.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -1192,8 +1200,8 @@ spec:
                     - name
                     type: object
                   targetSelector:
-                    description: Selector for a RegionTargetHTTPProxy to populate
-                      target.
+                    description: Selector for a RegionTargetHTTPProxy in compute to
+                      populate target.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/compute.gcp.upbound.io_globaladdresses.yaml
+++ b/package/crds/compute.gcp.upbound.io_globaladdresses.yaml
@@ -98,7 +98,7 @@ spec:
                       This should only be set when using an Internal address.
                     type: string
                   networkRef:
-                    description: Reference to a Network to populate network.
+                    description: Reference to a Network in compute to populate network.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -132,7 +132,7 @@ spec:
                     - name
                     type: object
                   networkSelector:
-                    description: Selector for a Network to populate network.
+                    description: Selector for a Network in compute to populate network.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -225,7 +225,7 @@ spec:
                       This should only be set when using an Internal address.
                     type: string
                   networkRef:
-                    description: Reference to a Network to populate network.
+                    description: Reference to a Network in compute to populate network.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -259,7 +259,7 @@ spec:
                     - name
                     type: object
                   networkSelector:
-                    description: Selector for a Network to populate network.
+                    description: Selector for a Network in compute to populate network.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/compute.gcp.upbound.io_havpngateways.yaml
+++ b/package/crds/compute.gcp.upbound.io_havpngateways.yaml
@@ -81,7 +81,7 @@ spec:
                       for.
                     type: string
                   networkRef:
-                    description: Reference to a Network to populate network.
+                    description: Reference to a Network in compute to populate network.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -115,7 +115,7 @@ spec:
                     - name
                     type: object
                   networkSelector:
-                    description: Selector for a Network to populate network.
+                    description: Selector for a Network in compute to populate network.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -289,7 +289,7 @@ spec:
                       for.
                     type: string
                   networkRef:
-                    description: Reference to a Network to populate network.
+                    description: Reference to a Network in compute to populate network.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -323,7 +323,7 @@ spec:
                     - name
                     type: object
                   networkSelector:
-                    description: Selector for a Network to populate network.
+                    description: Selector for a Network in compute to populate network.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/compute.gcp.upbound.io_imageiammembers.yaml
+++ b/package/crds/compute.gcp.upbound.io_imageiammembers.yaml
@@ -87,7 +87,7 @@ spec:
                   image:
                     type: string
                   imageRef:
-                    description: Reference to a Image to populate image.
+                    description: Reference to a Image in compute to populate image.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -121,7 +121,7 @@ spec:
                     - name
                     type: object
                   imageSelector:
-                    description: Selector for a Image to populate image.
+                    description: Selector for a Image in compute to populate image.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -194,7 +194,7 @@ spec:
                   image:
                     type: string
                   imageRef:
-                    description: Reference to a Image to populate image.
+                    description: Reference to a Image in compute to populate image.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -228,7 +228,7 @@ spec:
                     - name
                     type: object
                   imageSelector:
-                    description: Selector for a Image to populate image.
+                    description: Selector for a Image in compute to populate image.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/compute.gcp.upbound.io_instancefromtemplates.yaml
+++ b/package/crds/compute.gcp.upbound.io_instancefromtemplates.yaml
@@ -280,7 +280,8 @@ spec:
                         networkIp:
                           type: string
                         networkRef:
-                          description: Reference to a Network to populate network.
+                          description: Reference to a Network in compute to populate
+                            network.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -314,7 +315,8 @@ spec:
                           - name
                           type: object
                         networkSelector:
-                          description: Selector for a Network to populate network.
+                          description: Selector for a Network in compute to populate
+                            network.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -364,7 +366,8 @@ spec:
                         subnetworkProject:
                           type: string
                         subnetworkRef:
-                          description: Reference to a Subnetwork to populate subnetwork.
+                          description: Reference to a Subnetwork in compute to populate
+                            subnetwork.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -398,7 +401,8 @@ spec:
                           - name
                           type: object
                         subnetworkSelector:
-                          description: Selector for a Subnetwork to populate subnetwork.
+                          description: Selector for a Subnetwork in compute to populate
+                            subnetwork.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -564,7 +568,8 @@ spec:
                       instance templates through their unique id (self_link_unique attribute).
                     type: string
                   sourceInstanceTemplateRef:
-                    description: Reference to a InstanceTemplate to populate sourceInstanceTemplate.
+                    description: Reference to a InstanceTemplate in compute to populate
+                      sourceInstanceTemplate.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -598,7 +603,8 @@ spec:
                     - name
                     type: object
                   sourceInstanceTemplateSelector:
-                    description: Selector for a InstanceTemplate to populate sourceInstanceTemplate.
+                    description: Selector for a InstanceTemplate in compute to populate
+                      sourceInstanceTemplate.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -850,7 +856,8 @@ spec:
                         networkIp:
                           type: string
                         networkRef:
-                          description: Reference to a Network to populate network.
+                          description: Reference to a Network in compute to populate
+                            network.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -884,7 +891,8 @@ spec:
                           - name
                           type: object
                         networkSelector:
-                          description: Selector for a Network to populate network.
+                          description: Selector for a Network in compute to populate
+                            network.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -934,7 +942,8 @@ spec:
                         subnetworkProject:
                           type: string
                         subnetworkRef:
-                          description: Reference to a Subnetwork to populate subnetwork.
+                          description: Reference to a Subnetwork in compute to populate
+                            subnetwork.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -968,7 +977,8 @@ spec:
                           - name
                           type: object
                         subnetworkSelector:
-                          description: Selector for a Subnetwork to populate subnetwork.
+                          description: Selector for a Subnetwork in compute to populate
+                            subnetwork.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -1134,7 +1144,8 @@ spec:
                       instance templates through their unique id (self_link_unique attribute).
                     type: string
                   sourceInstanceTemplateRef:
-                    description: Reference to a InstanceTemplate to populate sourceInstanceTemplate.
+                    description: Reference to a InstanceTemplate in compute to populate
+                      sourceInstanceTemplate.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -1168,7 +1179,8 @@ spec:
                     - name
                     type: object
                   sourceInstanceTemplateSelector:
-                    description: Selector for a InstanceTemplate to populate sourceInstanceTemplate.
+                    description: Selector for a InstanceTemplate in compute to populate
+                      sourceInstanceTemplate.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/compute.gcp.upbound.io_instancegroupmanagers.yaml
+++ b/package/crds/compute.gcp.upbound.io_instancegroupmanagers.yaml
@@ -107,7 +107,8 @@ spec:
                           description: The health check resource that signals autohealing.
                           type: string
                         healthCheckRef:
-                          description: Reference to a HealthCheck to populate healthCheck.
+                          description: Reference to a HealthCheck in compute to populate
+                            healthCheck.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -141,7 +142,8 @@ spec:
                           - name
                           type: object
                         healthCheckSelector:
-                          description: Selector for a HealthCheck to populate healthCheck.
+                          description: Selector for a HealthCheck in compute to populate
+                            healthCheck.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -317,7 +319,7 @@ spec:
                     type: array
                     x-kubernetes-list-type: set
                   targetPoolsRefs:
-                    description: References to TargetPool to populate targetPools.
+                    description: References to TargetPool in compute to populate targetPools.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -354,7 +356,8 @@ spec:
                       type: object
                     type: array
                   targetPoolsSelector:
-                    description: Selector for a list of TargetPool to populate targetPools.
+                    description: Selector for a list of TargetPool in compute to populate
+                      targetPools.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -483,8 +486,8 @@ spec:
                             their unique id (self_link_unique attribute).'
                           type: string
                         instanceTemplateRef:
-                          description: Reference to a InstanceTemplate to populate
-                            instanceTemplate.
+                          description: Reference to a InstanceTemplate in compute
+                            to populate instanceTemplate.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -518,8 +521,8 @@ spec:
                           - name
                           type: object
                         instanceTemplateSelector:
-                          description: Selector for a InstanceTemplate to populate
-                            instanceTemplate.
+                          description: Selector for a InstanceTemplate in compute
+                            to populate instanceTemplate.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -648,7 +651,8 @@ spec:
                           description: The health check resource that signals autohealing.
                           type: string
                         healthCheckRef:
-                          description: Reference to a HealthCheck to populate healthCheck.
+                          description: Reference to a HealthCheck in compute to populate
+                            healthCheck.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -682,7 +686,8 @@ spec:
                           - name
                           type: object
                         healthCheckSelector:
-                          description: Selector for a HealthCheck to populate healthCheck.
+                          description: Selector for a HealthCheck in compute to populate
+                            healthCheck.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -858,7 +863,7 @@ spec:
                     type: array
                     x-kubernetes-list-type: set
                   targetPoolsRefs:
-                    description: References to TargetPool to populate targetPools.
+                    description: References to TargetPool in compute to populate targetPools.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -895,7 +900,8 @@ spec:
                       type: object
                     type: array
                   targetPoolsSelector:
-                    description: Selector for a list of TargetPool to populate targetPools.
+                    description: Selector for a list of TargetPool in compute to populate
+                      targetPools.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -1024,8 +1030,8 @@ spec:
                             their unique id (self_link_unique attribute).'
                           type: string
                         instanceTemplateRef:
-                          description: Reference to a InstanceTemplate to populate
-                            instanceTemplate.
+                          description: Reference to a InstanceTemplate in compute
+                            to populate instanceTemplate.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -1059,8 +1065,8 @@ spec:
                           - name
                           type: object
                         instanceTemplateSelector:
-                          description: Selector for a InstanceTemplate to populate
-                            instanceTemplate.
+                          description: Selector for a InstanceTemplate in compute
+                            to populate instanceTemplate.
                           properties:
                             matchControllerRef:
                               description: |-

--- a/package/crds/compute.gcp.upbound.io_instancegroups.yaml
+++ b/package/crds/compute.gcp.upbound.io_instancegroups.yaml
@@ -108,7 +108,7 @@ spec:
                       network nor instances is specified, this field will be blank).
                     type: string
                   networkRef:
-                    description: Reference to a Network to populate network.
+                    description: Reference to a Network in compute to populate network.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -142,7 +142,7 @@ spec:
                     - name
                     type: object
                   networkSelector:
-                    description: Selector for a Network to populate network.
+                    description: Selector for a Network in compute to populate network.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -241,7 +241,7 @@ spec:
                       network nor instances is specified, this field will be blank).
                     type: string
                   networkRef:
-                    description: Reference to a Network to populate network.
+                    description: Reference to a Network in compute to populate network.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -275,7 +275,7 @@ spec:
                     - name
                     type: object
                   networkSelector:
-                    description: Selector for a Network to populate network.
+                    description: Selector for a Network in compute to populate network.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/compute.gcp.upbound.io_instanceiammembers.yaml
+++ b/package/crds/compute.gcp.upbound.io_instanceiammembers.yaml
@@ -87,7 +87,7 @@ spec:
                   instanceName:
                     type: string
                   instanceNameRef:
-                    description: Reference to a Instance to populate instanceName.
+                    description: Reference to a Instance in compute to populate instanceName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -121,7 +121,7 @@ spec:
                     - name
                     type: object
                   instanceNameSelector:
-                    description: Selector for a Instance to populate instanceName.
+                    description: Selector for a Instance in compute to populate instanceName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -196,7 +196,7 @@ spec:
                   instanceName:
                     type: string
                   instanceNameRef:
-                    description: Reference to a Instance to populate instanceName.
+                    description: Reference to a Instance in compute to populate instanceName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -230,7 +230,7 @@ spec:
                     - name
                     type: object
                   instanceNameSelector:
-                    description: Selector for a Instance to populate instanceName.
+                    description: Selector for a Instance in compute to populate instanceName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/compute.gcp.upbound.io_instances.yaml
+++ b/package/crds/compute.gcp.upbound.io_instances.yaml
@@ -211,7 +211,8 @@ spec:
                                   These images can be referred by family name here.
                                 type: string
                               imageRef:
-                                description: Reference to a Image to populate image.
+                                description: Reference to a Image in compute to populate
+                                  image.
                                 properties:
                                   name:
                                     description: Name of the referenced object.
@@ -245,7 +246,8 @@ spec:
                                 - name
                                 type: object
                               imageSelector:
-                                description: Selector for a Image to populate image.
+                                description: Selector for a Image in compute to populate
+                                  image.
                                 properties:
                                   matchControllerRef:
                                     description: |-
@@ -562,7 +564,8 @@ spec:
                             empty, the address will be automatically assigned.
                           type: string
                         networkRef:
-                          description: Reference to a Network to populate network.
+                          description: Reference to a Network in compute to populate
+                            network.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -596,7 +599,8 @@ spec:
                           - name
                           type: object
                         networkSelector:
-                          description: Selector for a Network to populate network.
+                          description: Selector for a Network in compute to populate
+                            network.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -668,7 +672,8 @@ spec:
                             field is not provided, the provider project is used.
                           type: string
                         subnetworkRef:
-                          description: Reference to a Subnetwork to populate subnetwork.
+                          description: Reference to a Subnetwork in compute to populate
+                            subnetwork.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -702,7 +707,8 @@ spec:
                           - name
                           type: object
                         subnetworkSelector:
-                          description: Selector for a Subnetwork to populate subnetwork.
+                          description: Selector for a Subnetwork in compute to populate
+                            subnetwork.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -1177,7 +1183,8 @@ spec:
                                   These images can be referred by family name here.
                                 type: string
                               imageRef:
-                                description: Reference to a Image to populate image.
+                                description: Reference to a Image in compute to populate
+                                  image.
                                 properties:
                                   name:
                                     description: Name of the referenced object.
@@ -1211,7 +1218,8 @@ spec:
                                 - name
                                 type: object
                               imageSelector:
-                                description: Selector for a Image to populate image.
+                                description: Selector for a Image in compute to populate
+                                  image.
                                 properties:
                                   matchControllerRef:
                                     description: |-
@@ -1528,7 +1536,8 @@ spec:
                             empty, the address will be automatically assigned.
                           type: string
                         networkRef:
-                          description: Reference to a Network to populate network.
+                          description: Reference to a Network in compute to populate
+                            network.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -1562,7 +1571,8 @@ spec:
                           - name
                           type: object
                         networkSelector:
-                          description: Selector for a Network to populate network.
+                          description: Selector for a Network in compute to populate
+                            network.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -1634,7 +1644,8 @@ spec:
                             field is not provided, the provider project is used.
                           type: string
                         subnetworkRef:
-                          description: Reference to a Subnetwork to populate subnetwork.
+                          description: Reference to a Subnetwork in compute to populate
+                            subnetwork.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -1668,7 +1679,8 @@ spec:
                           - name
                           type: object
                         subnetworkSelector:
-                          description: Selector for a Subnetwork to populate subnetwork.
+                          description: Selector for a Subnetwork in compute to populate
+                            subnetwork.
                           properties:
                             matchControllerRef:
                               description: |-

--- a/package/crds/compute.gcp.upbound.io_instancetemplates.yaml
+++ b/package/crds/compute.gcp.upbound.io_instancetemplates.yaml
@@ -487,7 +487,8 @@ spec:
                             empty, the address will be automatically assigned.
                           type: string
                         networkRef:
-                          description: Reference to a Network to populate network.
+                          description: Reference to a Network in compute to populate
+                            network.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -521,7 +522,8 @@ spec:
                           - name
                           type: object
                         networkSelector:
-                          description: Selector for a Network to populate network.
+                          description: Selector for a Network in compute to populate
+                            network.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -587,7 +589,8 @@ spec:
                             If it is not provided, the provider project is used.
                           type: string
                         subnetworkRef:
-                          description: Reference to a Subnetwork to populate subnetwork.
+                          description: Reference to a Subnetwork in compute to populate
+                            subnetwork.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -621,7 +624,8 @@ spec:
                           - name
                           type: object
                         subnetworkSelector:
-                          description: Selector for a Subnetwork to populate subnetwork.
+                          description: Selector for a Subnetwork in compute to populate
+                            subnetwork.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -1380,7 +1384,8 @@ spec:
                             empty, the address will be automatically assigned.
                           type: string
                         networkRef:
-                          description: Reference to a Network to populate network.
+                          description: Reference to a Network in compute to populate
+                            network.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -1414,7 +1419,8 @@ spec:
                           - name
                           type: object
                         networkSelector:
-                          description: Selector for a Network to populate network.
+                          description: Selector for a Network in compute to populate
+                            network.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -1480,7 +1486,8 @@ spec:
                             If it is not provided, the provider project is used.
                           type: string
                         subnetworkRef:
-                          description: Reference to a Subnetwork to populate subnetwork.
+                          description: Reference to a Subnetwork in compute to populate
+                            subnetwork.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -1514,7 +1521,8 @@ spec:
                           - name
                           type: object
                         subnetworkSelector:
-                          description: Selector for a Subnetwork to populate subnetwork.
+                          description: Selector for a Subnetwork in compute to populate
+                            subnetwork.
                           properties:
                             matchControllerRef:
                               description: |-

--- a/package/crds/compute.gcp.upbound.io_interconnectattachments.yaml
+++ b/package/crds/compute.gcp.upbound.io_interconnectattachments.yaml
@@ -165,7 +165,7 @@ spec:
                       Cloud Router is configured.
                     type: string
                   routerRef:
-                    description: Reference to a Router to populate router.
+                    description: Reference to a Router in compute to populate router.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -199,7 +199,7 @@ spec:
                     - name
                     type: object
                   routerSelector:
-                    description: Selector for a Router to populate router.
+                    description: Selector for a Router in compute to populate router.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -361,7 +361,7 @@ spec:
                       Cloud Router is configured.
                     type: string
                   routerRef:
-                    description: Reference to a Router to populate router.
+                    description: Reference to a Router in compute to populate router.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -395,7 +395,7 @@ spec:
                     - name
                     type: object
                   routerSelector:
-                    description: Selector for a Router to populate router.
+                    description: Selector for a Router in compute to populate router.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/compute.gcp.upbound.io_networkendpointgroups.yaml
+++ b/package/crds/compute.gcp.upbound.io_networkendpointgroups.yaml
@@ -103,7 +103,7 @@ spec:
                       Possible values are: GCE_VM_IP, GCE_VM_IP_PORT, NON_GCP_PRIVATE_IP_PORT, INTERNET_IP_PORT, INTERNET_FQDN_PORT, SERVERLESS, PRIVATE_SERVICE_CONNECT.
                     type: string
                   networkRef:
-                    description: Reference to a Network to populate network.
+                    description: Reference to a Network in compute to populate network.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -137,7 +137,7 @@ spec:
                     - name
                     type: object
                   networkSelector:
-                    description: Selector for a Network to populate network.
+                    description: Selector for a Network in compute to populate network.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -186,7 +186,8 @@ spec:
                       in the NEG belong.
                     type: string
                   subnetworkRef:
-                    description: Reference to a Subnetwork to populate subnetwork.
+                    description: Reference to a Subnetwork in compute to populate
+                      subnetwork.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -220,7 +221,8 @@ spec:
                     - name
                     type: object
                   subnetworkSelector:
-                    description: Selector for a Subnetwork to populate subnetwork.
+                    description: Selector for a Subnetwork in compute to populate
+                      subnetwork.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -307,7 +309,7 @@ spec:
                       Possible values are: GCE_VM_IP, GCE_VM_IP_PORT, NON_GCP_PRIVATE_IP_PORT, INTERNET_IP_PORT, INTERNET_FQDN_PORT, SERVERLESS, PRIVATE_SERVICE_CONNECT.
                     type: string
                   networkRef:
-                    description: Reference to a Network to populate network.
+                    description: Reference to a Network in compute to populate network.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -341,7 +343,7 @@ spec:
                     - name
                     type: object
                   networkSelector:
-                    description: Selector for a Network to populate network.
+                    description: Selector for a Network in compute to populate network.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -390,7 +392,8 @@ spec:
                       in the NEG belong.
                     type: string
                   subnetworkRef:
-                    description: Reference to a Subnetwork to populate subnetwork.
+                    description: Reference to a Subnetwork in compute to populate
+                      subnetwork.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -424,7 +427,8 @@ spec:
                     - name
                     type: object
                   subnetworkSelector:
-                    description: Selector for a Subnetwork to populate subnetwork.
+                    description: Selector for a Subnetwork in compute to populate
+                      subnetwork.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/compute.gcp.upbound.io_regionbackendservices.yaml
+++ b/package/crds/compute.gcp.upbound.io_regionbackendservices.yaml
@@ -137,8 +137,8 @@ spec:
                             partial URL.
                           type: string
                         groupRef:
-                          description: Reference to a RegionInstanceGroupManager to
-                            populate group.
+                          description: Reference to a RegionInstanceGroupManager in
+                            compute to populate group.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -172,8 +172,8 @@ spec:
                           - name
                           type: object
                         groupSelector:
-                          description: Selector for a RegionInstanceGroupManager to
-                            populate group.
+                          description: Selector for a RegionInstanceGroupManager in
+                            compute to populate group.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -558,7 +558,8 @@ spec:
                     type: array
                     x-kubernetes-list-type: set
                   healthChecksRefs:
-                    description: References to RegionHealthCheck to populate healthChecks.
+                    description: References to RegionHealthCheck in compute to populate
+                      healthChecks.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -595,8 +596,8 @@ spec:
                       type: object
                     type: array
                   healthChecksSelector:
-                    description: Selector for a list of RegionHealthCheck to populate
-                      healthChecks.
+                    description: Selector for a list of RegionHealthCheck in compute
+                      to populate healthChecks.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -925,8 +926,8 @@ spec:
                             partial URL.
                           type: string
                         groupRef:
-                          description: Reference to a RegionInstanceGroupManager to
-                            populate group.
+                          description: Reference to a RegionInstanceGroupManager in
+                            compute to populate group.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -960,8 +961,8 @@ spec:
                           - name
                           type: object
                         groupSelector:
-                          description: Selector for a RegionInstanceGroupManager to
-                            populate group.
+                          description: Selector for a RegionInstanceGroupManager in
+                            compute to populate group.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -1346,7 +1347,8 @@ spec:
                     type: array
                     x-kubernetes-list-type: set
                   healthChecksRefs:
-                    description: References to RegionHealthCheck to populate healthChecks.
+                    description: References to RegionHealthCheck in compute to populate
+                      healthChecks.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -1383,8 +1385,8 @@ spec:
                       type: object
                     type: array
                   healthChecksSelector:
-                    description: Selector for a list of RegionHealthCheck to populate
-                      healthChecks.
+                    description: Selector for a list of RegionHealthCheck in compute
+                      to populate healthChecks.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/compute.gcp.upbound.io_regiondiskiammembers.yaml
+++ b/package/crds/compute.gcp.upbound.io_regiondiskiammembers.yaml
@@ -89,7 +89,8 @@ spec:
                   name:
                     type: string
                   nameRef:
-                    description: Reference to a RegionDisk to populate name.
+                    description: Reference to a RegionDisk in compute to populate
+                      name.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -123,7 +124,8 @@ spec:
                     - name
                     type: object
                   nameSelector:
-                    description: Selector for a RegionDisk to populate name.
+                    description: Selector for a RegionDisk in compute to populate
+                      name.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -198,7 +200,8 @@ spec:
                   name:
                     type: string
                   nameRef:
-                    description: Reference to a RegionDisk to populate name.
+                    description: Reference to a RegionDisk in compute to populate
+                      name.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -232,7 +235,8 @@ spec:
                     - name
                     type: object
                   nameSelector:
-                    description: Selector for a RegionDisk to populate name.
+                    description: Selector for a RegionDisk in compute to populate
+                      name.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/compute.gcp.upbound.io_regioninstancegroupmanagers.yaml
+++ b/package/crds/compute.gcp.upbound.io_regioninstancegroupmanagers.yaml
@@ -108,7 +108,8 @@ spec:
                           description: The health check resource that signals autohealing.
                           type: string
                         healthCheckRef:
-                          description: Reference to a HealthCheck to populate healthCheck.
+                          description: Reference to a HealthCheck in compute to populate
+                            healthCheck.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -142,7 +143,8 @@ spec:
                           - name
                           type: object
                         healthCheckSelector:
-                          description: Selector for a HealthCheck to populate healthCheck.
+                          description: Selector for a HealthCheck in compute to populate
+                            healthCheck.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -345,7 +347,7 @@ spec:
                     type: array
                     x-kubernetes-list-type: set
                   targetPoolsRefs:
-                    description: References to TargetPool to populate targetPools.
+                    description: References to TargetPool in compute to populate targetPools.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -382,7 +384,8 @@ spec:
                       type: object
                     type: array
                   targetPoolsSelector:
-                    description: Selector for a list of TargetPool to populate targetPools.
+                    description: Selector for a list of TargetPool in compute to populate
+                      targetPools.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -524,8 +527,8 @@ spec:
                             which all new instances of this version will be created.'
                           type: string
                         instanceTemplateRef:
-                          description: Reference to a InstanceTemplate to populate
-                            instanceTemplate.
+                          description: Reference to a InstanceTemplate in compute
+                            to populate instanceTemplate.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -559,8 +562,8 @@ spec:
                           - name
                           type: object
                         instanceTemplateSelector:
-                          description: Selector for a InstanceTemplate to populate
-                            instanceTemplate.
+                          description: Selector for a InstanceTemplate in compute
+                            to populate instanceTemplate.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -682,7 +685,8 @@ spec:
                           description: The health check resource that signals autohealing.
                           type: string
                         healthCheckRef:
-                          description: Reference to a HealthCheck to populate healthCheck.
+                          description: Reference to a HealthCheck in compute to populate
+                            healthCheck.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -716,7 +720,8 @@ spec:
                           - name
                           type: object
                         healthCheckSelector:
-                          description: Selector for a HealthCheck to populate healthCheck.
+                          description: Selector for a HealthCheck in compute to populate
+                            healthCheck.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -919,7 +924,7 @@ spec:
                     type: array
                     x-kubernetes-list-type: set
                   targetPoolsRefs:
-                    description: References to TargetPool to populate targetPools.
+                    description: References to TargetPool in compute to populate targetPools.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -956,7 +961,8 @@ spec:
                       type: object
                     type: array
                   targetPoolsSelector:
-                    description: Selector for a list of TargetPool to populate targetPools.
+                    description: Selector for a list of TargetPool in compute to populate
+                      targetPools.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -1098,8 +1104,8 @@ spec:
                             which all new instances of this version will be created.'
                           type: string
                         instanceTemplateRef:
-                          description: Reference to a InstanceTemplate to populate
-                            instanceTemplate.
+                          description: Reference to a InstanceTemplate in compute
+                            to populate instanceTemplate.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -1133,8 +1139,8 @@ spec:
                           - name
                           type: object
                         instanceTemplateSelector:
-                          description: Selector for a InstanceTemplate to populate
-                            instanceTemplate.
+                          description: Selector for a InstanceTemplate in compute
+                            to populate instanceTemplate.
                           properties:
                             matchControllerRef:
                               description: |-

--- a/package/crds/compute.gcp.upbound.io_regiontargethttpproxies.yaml
+++ b/package/crds/compute.gcp.upbound.io_regiontargethttpproxies.yaml
@@ -93,7 +93,8 @@ spec:
                       to the BackendService.
                     type: string
                   urlMapRef:
-                    description: Reference to a RegionURLMap to populate urlMap.
+                    description: Reference to a RegionURLMap in compute to populate
+                      urlMap.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -127,7 +128,8 @@ spec:
                     - name
                     type: object
                   urlMapSelector:
-                    description: Selector for a RegionURLMap to populate urlMap.
+                    description: Selector for a RegionURLMap in compute to populate
+                      urlMap.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -196,7 +198,8 @@ spec:
                       to the BackendService.
                     type: string
                   urlMapRef:
-                    description: Reference to a RegionURLMap to populate urlMap.
+                    description: Reference to a RegionURLMap in compute to populate
+                      urlMap.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -230,7 +233,8 @@ spec:
                     - name
                     type: object
                   urlMapSelector:
-                    description: Selector for a RegionURLMap to populate urlMap.
+                    description: Selector for a RegionURLMap in compute to populate
+                      urlMap.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/compute.gcp.upbound.io_regiontargethttpsproxies.yaml
+++ b/package/crds/compute.gcp.upbound.io_regiontargethttpsproxies.yaml
@@ -105,7 +105,8 @@ spec:
                       type: string
                     type: array
                   sslCertificatesRefs:
-                    description: References to RegionSSLCertificate to populate sslCertificates.
+                    description: References to RegionSSLCertificate in compute to
+                      populate sslCertificates.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -142,8 +143,8 @@ spec:
                       type: object
                     type: array
                   sslCertificatesSelector:
-                    description: Selector for a list of RegionSSLCertificate to populate
-                      sslCertificates.
+                    description: Selector for a list of RegionSSLCertificate in compute
+                      to populate sslCertificates.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -311,7 +312,8 @@ spec:
                       type: string
                     type: array
                   sslCertificatesRefs:
-                    description: References to RegionSSLCertificate to populate sslCertificates.
+                    description: References to RegionSSLCertificate in compute to
+                      populate sslCertificates.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -348,8 +350,8 @@ spec:
                       type: object
                     type: array
                   sslCertificatesSelector:
-                    description: Selector for a list of RegionSSLCertificate to populate
-                      sslCertificates.
+                    description: Selector for a list of RegionSSLCertificate in compute
+                      to populate sslCertificates.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/compute.gcp.upbound.io_routerinterfaces.yaml
+++ b/package/crds/compute.gcp.upbound.io_routerinterfaces.yaml
@@ -115,7 +115,7 @@ spec:
                       Changing this forces a new interface to be created.
                     type: string
                   routerRef:
-                    description: Reference to a Router to populate router.
+                    description: Reference to a Router in compute to populate router.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -149,7 +149,7 @@ spec:
                     - name
                     type: object
                   routerSelector:
-                    description: Selector for a Router to populate router.
+                    description: Selector for a Router in compute to populate router.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -200,7 +200,7 @@ spec:
                       one of vpn_tunnel, interconnect_attachment or subnetwork can be specified.
                     type: string
                   vpnTunnelRef:
-                    description: Reference to a VPNTunnel to populate vpnTunnel.
+                    description: Reference to a VPNTunnel in compute to populate vpnTunnel.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -234,7 +234,7 @@ spec:
                     - name
                     type: object
                   vpnTunnelSelector:
-                    description: Selector for a VPNTunnel to populate vpnTunnel.
+                    description: Selector for a VPNTunnel in compute to populate vpnTunnel.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -329,7 +329,7 @@ spec:
                       Changing this forces a new interface to be created.
                     type: string
                   routerRef:
-                    description: Reference to a Router to populate router.
+                    description: Reference to a Router in compute to populate router.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -363,7 +363,7 @@ spec:
                     - name
                     type: object
                   routerSelector:
-                    description: Selector for a Router to populate router.
+                    description: Selector for a Router in compute to populate router.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -414,7 +414,7 @@ spec:
                       one of vpn_tunnel, interconnect_attachment or subnetwork can be specified.
                     type: string
                   vpnTunnelRef:
-                    description: Reference to a VPNTunnel to populate vpnTunnel.
+                    description: Reference to a VPNTunnel in compute to populate vpnTunnel.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -448,7 +448,7 @@ spec:
                     - name
                     type: object
                   vpnTunnelSelector:
-                    description: Selector for a VPNTunnel to populate vpnTunnel.
+                    description: Selector for a VPNTunnel in compute to populate vpnTunnel.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/compute.gcp.upbound.io_routernats.yaml
+++ b/package/crds/compute.gcp.upbound.io_routernats.yaml
@@ -153,7 +153,7 @@ spec:
                       be configured.
                     type: string
                   routerRef:
-                    description: Reference to a Router to populate router.
+                    description: Reference to a Router in compute to populate router.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -187,7 +187,7 @@ spec:
                     - name
                     type: object
                   routerSelector:
-                    description: Selector for a Router to populate router.
+                    description: Selector for a Router in compute to populate router.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -304,7 +304,8 @@ spec:
                           description: Self-link of subnetwork to NAT
                           type: string
                         nameRef:
-                          description: Reference to a Subnetwork to populate name.
+                          description: Reference to a Subnetwork in compute to populate
+                            name.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -338,7 +339,8 @@ spec:
                           - name
                           type: object
                         nameSelector:
-                          description: Selector for a Subnetwork to populate name.
+                          description: Selector for a Subnetwork in compute to populate
+                            name.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -584,7 +586,8 @@ spec:
                           description: Self-link of subnetwork to NAT
                           type: string
                         nameRef:
-                          description: Reference to a Subnetwork to populate name.
+                          description: Reference to a Subnetwork in compute to populate
+                            name.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -618,7 +621,8 @@ spec:
                           - name
                           type: object
                         nameSelector:
-                          description: Selector for a Subnetwork to populate name.
+                          description: Selector for a Subnetwork in compute to populate
+                            name.
                           properties:
                             matchControllerRef:
                               description: |-

--- a/package/crds/compute.gcp.upbound.io_routers.yaml
+++ b/package/crds/compute.gcp.upbound.io_routers.yaml
@@ -149,7 +149,7 @@ spec:
                     description: A reference to the network to which this router belongs.
                     type: string
                   networkRef:
-                    description: Reference to a Network to populate network.
+                    description: Reference to a Network in compute to populate network.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -183,7 +183,7 @@ spec:
                     - name
                     type: object
                   networkSelector:
-                    description: Selector for a Network to populate network.
+                    description: Selector for a Network in compute to populate network.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -322,7 +322,7 @@ spec:
                     description: A reference to the network to which this router belongs.
                     type: string
                   networkRef:
-                    description: Reference to a Network to populate network.
+                    description: Reference to a Network in compute to populate network.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -356,7 +356,7 @@ spec:
                     - name
                     type: object
                   networkSelector:
-                    description: Selector for a Network to populate network.
+                    description: Selector for a Network in compute to populate network.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/compute.gcp.upbound.io_routes.yaml
+++ b/package/crds/compute.gcp.upbound.io_routes.yaml
@@ -266,7 +266,7 @@ spec:
                     description: URL to a VpnTunnel that should handle matching packets.
                     type: string
                   nextHopVpnTunnelRef:
-                    description: Reference to a VPNTunnel to populate nextHopVpnTunnel.
+                    description: Reference to a VPNTunnel in compute to populate nextHopVpnTunnel.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -300,7 +300,7 @@ spec:
                     - name
                     type: object
                   nextHopVpnTunnelSelector:
-                    description: Selector for a VPNTunnel to populate nextHopVpnTunnel.
+                    description: Selector for a VPNTunnel in compute to populate nextHopVpnTunnel.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -566,7 +566,7 @@ spec:
                     description: URL to a VpnTunnel that should handle matching packets.
                     type: string
                   nextHopVpnTunnelRef:
-                    description: Reference to a VPNTunnel to populate nextHopVpnTunnel.
+                    description: Reference to a VPNTunnel in compute to populate nextHopVpnTunnel.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -600,7 +600,7 @@ spec:
                     - name
                     type: object
                   nextHopVpnTunnelSelector:
-                    description: Selector for a VPNTunnel to populate nextHopVpnTunnel.
+                    description: Selector for a VPNTunnel in compute to populate nextHopVpnTunnel.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/compute.gcp.upbound.io_serviceattachments.yaml
+++ b/package/crds/compute.gcp.upbound.io_serviceattachments.yaml
@@ -128,7 +128,7 @@ spec:
                       type: string
                     type: array
                   natSubnetsRefs:
-                    description: References to Subnetwork to populate natSubnets.
+                    description: References to Subnetwork in compute to populate natSubnets.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -165,7 +165,8 @@ spec:
                       type: object
                     type: array
                   natSubnetsSelector:
-                    description: Selector for a list of Subnetwork to populate natSubnets.
+                    description: Selector for a list of Subnetwork in compute to populate
+                      natSubnets.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -370,7 +371,7 @@ spec:
                       type: string
                     type: array
                   natSubnetsRefs:
-                    description: References to Subnetwork to populate natSubnets.
+                    description: References to Subnetwork in compute to populate natSubnets.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -407,7 +408,8 @@ spec:
                       type: object
                     type: array
                   natSubnetsSelector:
-                    description: Selector for a list of Subnetwork to populate natSubnets.
+                    description: Selector for a list of Subnetwork in compute to populate
+                      natSubnets.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/compute.gcp.upbound.io_subnetworkiammembers.yaml
+++ b/package/crds/compute.gcp.upbound.io_subnetworkiammembers.yaml
@@ -95,7 +95,8 @@ spec:
                   subnetwork:
                     type: string
                   subnetworkRef:
-                    description: Reference to a Subnetwork to populate subnetwork.
+                    description: Reference to a Subnetwork in compute to populate
+                      subnetwork.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -129,7 +130,8 @@ spec:
                     - name
                     type: object
                   subnetworkSelector:
-                    description: Selector for a Subnetwork to populate subnetwork.
+                    description: Selector for a Subnetwork in compute to populate
+                      subnetwork.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -204,7 +206,8 @@ spec:
                   subnetwork:
                     type: string
                   subnetworkRef:
-                    description: Reference to a Subnetwork to populate subnetwork.
+                    description: Reference to a Subnetwork in compute to populate
+                      subnetwork.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -238,7 +241,8 @@ spec:
                     - name
                     type: object
                   subnetworkSelector:
-                    description: Selector for a Subnetwork to populate subnetwork.
+                    description: Selector for a Subnetwork in compute to populate
+                      subnetwork.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/compute.gcp.upbound.io_subnetworks.yaml
+++ b/package/crds/compute.gcp.upbound.io_subnetworks.yaml
@@ -154,7 +154,7 @@ spec:
                       Only networks that are in the distributed mode can have subnetworks.
                     type: string
                   networkRef:
-                    description: Reference to a Network to populate network.
+                    description: Reference to a Network in compute to populate network.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -188,7 +188,7 @@ spec:
                     - name
                     type: object
                   networkSelector:
-                    description: Selector for a Network to populate network.
+                    description: Selector for a Network in compute to populate network.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -395,7 +395,7 @@ spec:
                       Only networks that are in the distributed mode can have subnetworks.
                     type: string
                   networkRef:
-                    description: Reference to a Network to populate network.
+                    description: Reference to a Network in compute to populate network.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -429,7 +429,7 @@ spec:
                     - name
                     type: object
                   networkSelector:
-                    description: Selector for a Network to populate network.
+                    description: Selector for a Network in compute to populate network.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/compute.gcp.upbound.io_targethttpsproxies.yaml
+++ b/package/crds/compute.gcp.upbound.io_targethttpsproxies.yaml
@@ -141,7 +141,8 @@ spec:
                       type: string
                     type: array
                   sslCertificatesRefs:
-                    description: References to SSLCertificate to populate sslCertificates.
+                    description: References to SSLCertificate in compute to populate
+                      sslCertificates.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -178,8 +179,8 @@ spec:
                       type: object
                     type: array
                   sslCertificatesSelector:
-                    description: Selector for a list of SSLCertificate to populate
-                      sslCertificates.
+                    description: Selector for a list of SSLCertificate in compute
+                      to populate sslCertificates.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -384,7 +385,8 @@ spec:
                       type: string
                     type: array
                   sslCertificatesRefs:
-                    description: References to SSLCertificate to populate sslCertificates.
+                    description: References to SSLCertificate in compute to populate
+                      sslCertificates.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -421,8 +423,8 @@ spec:
                       type: object
                     type: array
                   sslCertificatesSelector:
-                    description: Selector for a list of SSLCertificate to populate
-                      sslCertificates.
+                    description: Selector for a list of SSLCertificate in compute
+                      to populate sslCertificates.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/compute.gcp.upbound.io_targetpools.yaml
+++ b/package/crds/compute.gcp.upbound.io_targetpools.yaml
@@ -94,7 +94,8 @@ spec:
                       type: string
                     type: array
                   healthChecksRefs:
-                    description: References to HTTPHealthCheck to populate healthChecks.
+                    description: References to HTTPHealthCheck in compute to populate
+                      healthChecks.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -131,8 +132,8 @@ spec:
                       type: object
                     type: array
                   healthChecksSelector:
-                    description: Selector for a list of HTTPHealthCheck to populate
-                      healthChecks.
+                    description: Selector for a list of HTTPHealthCheck in compute
+                      to populate healthChecks.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -232,7 +233,8 @@ spec:
                       type: string
                     type: array
                   healthChecksRefs:
-                    description: References to HTTPHealthCheck to populate healthChecks.
+                    description: References to HTTPHealthCheck in compute to populate
+                      healthChecks.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -269,8 +271,8 @@ spec:
                       type: object
                     type: array
                   healthChecksSelector:
-                    description: Selector for a list of HTTPHealthCheck to populate
-                      healthChecks.
+                    description: Selector for a list of HTTPHealthCheck in compute
+                      to populate healthChecks.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/compute.gcp.upbound.io_targetsslproxies.yaml
+++ b/package/crds/compute.gcp.upbound.io_targetsslproxies.yaml
@@ -183,7 +183,8 @@ spec:
                       type: string
                     type: array
                   sslCertificatesRefs:
-                    description: References to SSLCertificate to populate sslCertificates.
+                    description: References to SSLCertificate in compute to populate
+                      sslCertificates.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -220,8 +221,8 @@ spec:
                       type: object
                     type: array
                   sslCertificatesSelector:
-                    description: Selector for a list of SSLCertificate to populate
-                      sslCertificates.
+                    description: Selector for a list of SSLCertificate in compute
+                      to populate sslCertificates.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -389,7 +390,8 @@ spec:
                       type: string
                     type: array
                   sslCertificatesRefs:
-                    description: References to SSLCertificate to populate sslCertificates.
+                    description: References to SSLCertificate in compute to populate
+                      sslCertificates.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -426,8 +428,8 @@ spec:
                       type: object
                     type: array
                   sslCertificatesSelector:
-                    description: Selector for a list of SSLCertificate to populate
-                      sslCertificates.
+                    description: Selector for a list of SSLCertificate in compute
+                      to populate sslCertificates.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/compute.gcp.upbound.io_vpntunnels.yaml
+++ b/package/crds/compute.gcp.upbound.io_vpntunnels.yaml
@@ -109,7 +109,8 @@ spec:
                       this VPN tunnel is connected.
                     type: number
                   peerExternalGatewayRef:
-                    description: Reference to a ExternalVPNGateway to populate peerExternalGateway.
+                    description: Reference to a ExternalVPNGateway in compute to populate
+                      peerExternalGateway.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -143,7 +144,8 @@ spec:
                     - name
                     type: object
                   peerExternalGatewaySelector:
-                    description: Selector for a ExternalVPNGateway to populate peerExternalGateway.
+                    description: Selector for a ExternalVPNGateway in compute to populate
+                      peerExternalGateway.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -216,7 +218,7 @@ spec:
                     description: URL of router resource to be used for dynamic routing.
                     type: string
                   routerRef:
-                    description: Reference to a Router to populate router.
+                    description: Reference to a Router in compute to populate router.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -250,7 +252,7 @@ spec:
                     - name
                     type: object
                   routerSelector:
-                    description: Selector for a Router to populate router.
+                    description: Selector for a Router in compute to populate router.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -401,7 +403,8 @@ spec:
                       VPN tunnel is associated.
                     type: number
                   vpnGatewayRef:
-                    description: Reference to a HaVPNGateway to populate vpnGateway.
+                    description: Reference to a HaVPNGateway in compute to populate
+                      vpnGateway.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -435,7 +438,8 @@ spec:
                     - name
                     type: object
                   vpnGatewaySelector:
-                    description: Selector for a HaVPNGateway to populate vpnGateway.
+                    description: Selector for a HaVPNGateway in compute to populate
+                      vpnGateway.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -527,7 +531,8 @@ spec:
                       this VPN tunnel is connected.
                     type: number
                   peerExternalGatewayRef:
-                    description: Reference to a ExternalVPNGateway to populate peerExternalGateway.
+                    description: Reference to a ExternalVPNGateway in compute to populate
+                      peerExternalGateway.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -561,7 +566,8 @@ spec:
                     - name
                     type: object
                   peerExternalGatewaySelector:
-                    description: Selector for a ExternalVPNGateway to populate peerExternalGateway.
+                    description: Selector for a ExternalVPNGateway in compute to populate
+                      peerExternalGateway.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -630,7 +636,7 @@ spec:
                     description: URL of router resource to be used for dynamic routing.
                     type: string
                   routerRef:
-                    description: Reference to a Router to populate router.
+                    description: Reference to a Router in compute to populate router.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -664,7 +670,7 @@ spec:
                     - name
                     type: object
                   routerSelector:
-                    description: Selector for a Router to populate router.
+                    description: Selector for a Router in compute to populate router.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -795,7 +801,8 @@ spec:
                       VPN tunnel is associated.
                     type: number
                   vpnGatewayRef:
-                    description: Reference to a HaVPNGateway to populate vpnGateway.
+                    description: Reference to a HaVPNGateway in compute to populate
+                      vpnGateway.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -829,7 +836,8 @@ spec:
                     - name
                     type: object
                   vpnGatewaySelector:
-                    description: Selector for a HaVPNGateway to populate vpnGateway.
+                    description: Selector for a HaVPNGateway in compute to populate
+                      vpnGateway.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/container.gcp.upbound.io_nodepools.yaml
+++ b/package/crds/container.gcp.upbound.io_nodepools.yaml
@@ -115,7 +115,7 @@ spec:
                       or as just the name of the cluster.
                     type: string
                   clusterRef:
-                    description: Reference to a Cluster to populate cluster.
+                    description: Reference to a Cluster in container to populate cluster.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -149,7 +149,7 @@ spec:
                     - name
                     type: object
                   clusterSelector:
-                    description: Selector for a Cluster to populate cluster.
+                    description: Selector for a Cluster in container to populate cluster.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/containeraws.gcp.upbound.io_nodepools.yaml
+++ b/package/crds/containeraws.gcp.upbound.io_nodepools.yaml
@@ -103,7 +103,8 @@ spec:
                     description: The awsCluster for the resource
                     type: string
                   clusterRef:
-                    description: Reference to a Cluster to populate cluster.
+                    description: Reference to a Cluster in containeraws to populate
+                      cluster.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -137,7 +138,8 @@ spec:
                     - name
                     type: object
                   clusterSelector:
-                    description: Selector for a Cluster to populate cluster.
+                    description: Selector for a Cluster in containeraws to populate
+                      cluster.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/containerazure.gcp.upbound.io_nodepools.yaml
+++ b/package/crds/containerazure.gcp.upbound.io_nodepools.yaml
@@ -107,7 +107,8 @@ spec:
                     description: The azureCluster for the resource
                     type: string
                   clusterRef:
-                    description: Reference to a Cluster to populate cluster.
+                    description: Reference to a Cluster in containerazure to populate
+                      cluster.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -141,7 +142,8 @@ spec:
                     - name
                     type: object
                   clusterSelector:
-                    description: Selector for a Cluster to populate cluster.
+                    description: Selector for a Cluster in containerazure to populate
+                      cluster.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/firebaserules.gcp.upbound.io_releases.yaml
+++ b/package/crds/firebaserules.gcp.upbound.io_releases.yaml
@@ -80,7 +80,8 @@ spec:
                       The Ruleset must exist for the Release to be created.
                     type: string
                   rulesetNameRef:
-                    description: Reference to a Ruleset to populate rulesetName.
+                    description: Reference to a Ruleset in firebaserules to populate
+                      rulesetName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -114,7 +115,8 @@ spec:
                     - name
                     type: object
                   rulesetNameSelector:
-                    description: Selector for a Ruleset to populate rulesetName.
+                    description: Selector for a Ruleset in firebaserules to populate
+                      rulesetName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -175,7 +177,8 @@ spec:
                       The Ruleset must exist for the Release to be created.
                     type: string
                   rulesetNameRef:
-                    description: Reference to a Ruleset to populate rulesetName.
+                    description: Reference to a Ruleset in firebaserules to populate
+                      rulesetName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -209,7 +212,8 @@ spec:
                     - name
                     type: object
                   rulesetNameSelector:
-                    description: Selector for a Ruleset to populate rulesetName.
+                    description: Selector for a Ruleset in firebaserules to populate
+                      rulesetName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/kms.gcp.upbound.io_cryptokeyiammembers.yaml
+++ b/package/crds/kms.gcp.upbound.io_cryptokeyiammembers.yaml
@@ -87,7 +87,7 @@ spec:
                   cryptoKeyId:
                     type: string
                   cryptoKeyIdRef:
-                    description: Reference to a CryptoKey to populate cryptoKeyId.
+                    description: Reference to a CryptoKey in kms to populate cryptoKeyId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -121,7 +121,7 @@ spec:
                     - name
                     type: object
                   cryptoKeyIdSelector:
-                    description: Selector for a CryptoKey to populate cryptoKeyId.
+                    description: Selector for a CryptoKey in kms to populate cryptoKeyId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -192,7 +192,7 @@ spec:
                   cryptoKeyId:
                     type: string
                   cryptoKeyIdRef:
-                    description: Reference to a CryptoKey to populate cryptoKeyId.
+                    description: Reference to a CryptoKey in kms to populate cryptoKeyId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -226,7 +226,7 @@ spec:
                     - name
                     type: object
                   cryptoKeyIdSelector:
-                    description: Selector for a CryptoKey to populate cryptoKeyId.
+                    description: Selector for a CryptoKey in kms to populate cryptoKeyId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/kms.gcp.upbound.io_keyringiammembers.yaml
+++ b/package/crds/kms.gcp.upbound.io_keyringiammembers.yaml
@@ -87,7 +87,7 @@ spec:
                   keyRingId:
                     type: string
                   keyRingIdRef:
-                    description: Reference to a KeyRing to populate keyRingId.
+                    description: Reference to a KeyRing in kms to populate keyRingId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -121,7 +121,7 @@ spec:
                     - name
                     type: object
                   keyRingIdSelector:
-                    description: Selector for a KeyRing to populate keyRingId.
+                    description: Selector for a KeyRing in kms to populate keyRingId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -192,7 +192,7 @@ spec:
                   keyRingId:
                     type: string
                   keyRingIdRef:
-                    description: Reference to a KeyRing to populate keyRingId.
+                    description: Reference to a KeyRing in kms to populate keyRingId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -226,7 +226,7 @@ spec:
                     - name
                     type: object
                   keyRingIdSelector:
-                    description: Selector for a KeyRing to populate keyRingId.
+                    description: Selector for a KeyRing in kms to populate keyRingId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/kms.gcp.upbound.io_keyringimportjobs.yaml
+++ b/package/crds/kms.gcp.upbound.io_keyringimportjobs.yaml
@@ -84,7 +84,7 @@ spec:
                       Format: 'projects/{{project}}/locations/{{location}}/keyRings/{{keyRing}}'.
                     type: string
                   keyRingRef:
-                    description: Reference to a KeyRing to populate keyRing.
+                    description: Reference to a KeyRing in kms to populate keyRing.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -118,7 +118,7 @@ spec:
                     - name
                     type: object
                   keyRingSelector:
-                    description: Selector for a KeyRing to populate keyRing.
+                    description: Selector for a KeyRing in kms to populate keyRing.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/notebooks.gcp.upbound.io_instanceiammembers.yaml
+++ b/package/crds/notebooks.gcp.upbound.io_instanceiammembers.yaml
@@ -87,7 +87,8 @@ spec:
                   instanceName:
                     type: string
                   instanceNameRef:
-                    description: Reference to a Instance to populate instanceName.
+                    description: Reference to a Instance in notebooks to populate
+                      instanceName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -121,7 +122,8 @@ spec:
                     - name
                     type: object
                   instanceNameSelector:
-                    description: Selector for a Instance to populate instanceName.
+                    description: Selector for a Instance in notebooks to populate
+                      instanceName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -196,7 +198,8 @@ spec:
                   instanceName:
                     type: string
                   instanceNameRef:
-                    description: Reference to a Instance to populate instanceName.
+                    description: Reference to a Instance in notebooks to populate
+                      instanceName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -230,7 +233,8 @@ spec:
                     - name
                     type: object
                   instanceNameSelector:
-                    description: Selector for a Instance to populate instanceName.
+                    description: Selector for a Instance in notebooks to populate
+                      instanceName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/notebooks.gcp.upbound.io_runtimeiammembers.yaml
+++ b/package/crds/notebooks.gcp.upbound.io_runtimeiammembers.yaml
@@ -95,7 +95,7 @@ spec:
                   runtimeName:
                     type: string
                   runtimeNameRef:
-                    description: Reference to a Runtime to populate runtimeName.
+                    description: Reference to a Runtime in notebooks to populate runtimeName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -129,7 +129,7 @@ spec:
                     - name
                     type: object
                   runtimeNameSelector:
-                    description: Selector for a Runtime to populate runtimeName.
+                    description: Selector for a Runtime in notebooks to populate runtimeName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -204,7 +204,7 @@ spec:
                   runtimeName:
                     type: string
                   runtimeNameRef:
-                    description: Reference to a Runtime to populate runtimeName.
+                    description: Reference to a Runtime in notebooks to populate runtimeName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -238,7 +238,7 @@ spec:
                     - name
                     type: object
                   runtimeNameSelector:
-                    description: Selector for a Runtime to populate runtimeName.
+                    description: Selector for a Runtime in notebooks to populate runtimeName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/privateca.gcp.upbound.io_capooliammembers.yaml
+++ b/package/crds/privateca.gcp.upbound.io_capooliammembers.yaml
@@ -76,7 +76,7 @@ spec:
                   caPool:
                     type: string
                   caPoolRef:
-                    description: Reference to a CAPool to populate caPool.
+                    description: Reference to a CAPool in privateca to populate caPool.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -110,7 +110,7 @@ spec:
                     - name
                     type: object
                   caPoolSelector:
-                    description: Selector for a CAPool to populate caPool.
+                    description: Selector for a CAPool in privateca to populate caPool.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -185,7 +185,7 @@ spec:
                   caPool:
                     type: string
                   caPoolRef:
-                    description: Reference to a CAPool to populate caPool.
+                    description: Reference to a CAPool in privateca to populate caPool.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -219,7 +219,7 @@ spec:
                     - name
                     type: object
                   caPoolSelector:
-                    description: Selector for a CAPool to populate caPool.
+                    description: Selector for a CAPool in privateca to populate caPool.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/privateca.gcp.upbound.io_certificateauthorities.yaml
+++ b/package/crds/privateca.gcp.upbound.io_certificateauthorities.yaml
@@ -509,7 +509,7 @@ spec:
                       belongs to.
                     type: string
                   poolRef:
-                    description: Reference to a CAPool to populate pool.
+                    description: Reference to a CAPool in privateca to populate pool.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -543,7 +543,7 @@ spec:
                     - name
                     type: object
                   poolSelector:
-                    description: Selector for a CAPool to populate pool.
+                    description: Selector for a CAPool in privateca to populate pool.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/privateca.gcp.upbound.io_certificates.yaml
+++ b/package/crds/privateca.gcp.upbound.io_certificates.yaml
@@ -676,7 +676,7 @@ spec:
                     description: The name of the CaPool this Certificate belongs to.
                     type: string
                   poolRef:
-                    description: Reference to a CAPool to populate pool.
+                    description: Reference to a CAPool in privateca to populate pool.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -710,7 +710,7 @@ spec:
                     - name
                     type: object
                   poolSelector:
-                    description: Selector for a CAPool to populate pool.
+                    description: Selector for a CAPool in privateca to populate pool.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/privateca.gcp.upbound.io_certificatetemplateiammembers.yaml
+++ b/package/crds/privateca.gcp.upbound.io_certificatetemplateiammembers.yaml
@@ -77,7 +77,8 @@ spec:
                   certificateTemplate:
                     type: string
                   certificateTemplateRef:
-                    description: Reference to a CertificateTemplate to populate certificateTemplate.
+                    description: Reference to a CertificateTemplate in privateca to
+                      populate certificateTemplate.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -111,7 +112,8 @@ spec:
                     - name
                     type: object
                   certificateTemplateSelector:
-                    description: Selector for a CertificateTemplate to populate certificateTemplate.
+                    description: Selector for a CertificateTemplate in privateca to
+                      populate certificateTemplate.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -186,7 +188,8 @@ spec:
                   certificateTemplate:
                     type: string
                   certificateTemplateRef:
-                    description: Reference to a CertificateTemplate to populate certificateTemplate.
+                    description: Reference to a CertificateTemplate in privateca to
+                      populate certificateTemplate.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -220,7 +223,8 @@ spec:
                     - name
                     type: object
                   certificateTemplateSelector:
-                    description: Selector for a CertificateTemplate to populate certificateTemplate.
+                    description: Selector for a CertificateTemplate in privateca to
+                      populate certificateTemplate.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/pubsub.gcp.upbound.io_litesubscriptions.yaml
+++ b/package/crds/pubsub.gcp.upbound.io_litesubscriptions.yaml
@@ -99,7 +99,7 @@ spec:
                     description: A reference to a Topic resource.
                     type: string
                   topicRef:
-                    description: Reference to a LiteTopic to populate topic.
+                    description: Reference to a LiteTopic in pubsub to populate topic.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -133,7 +133,7 @@ spec:
                     - name
                     type: object
                   topicSelector:
-                    description: Selector for a LiteTopic to populate topic.
+                    description: Selector for a LiteTopic in pubsub to populate topic.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -216,7 +216,7 @@ spec:
                     description: A reference to a Topic resource.
                     type: string
                   topicRef:
-                    description: Reference to a LiteTopic to populate topic.
+                    description: Reference to a LiteTopic in pubsub to populate topic.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -250,7 +250,7 @@ spec:
                     - name
                     type: object
                   topicSelector:
-                    description: Selector for a LiteTopic to populate topic.
+                    description: Selector for a LiteTopic in pubsub to populate topic.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/pubsub.gcp.upbound.io_litetopics.yaml
+++ b/package/crds/pubsub.gcp.upbound.io_litetopics.yaml
@@ -120,8 +120,8 @@ spec:
                             capacity.
                           type: string
                         throughputReservationRef:
-                          description: Reference to a LiteReservation to populate
-                            throughputReservation.
+                          description: Reference to a LiteReservation in pubsub to
+                            populate throughputReservation.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -155,8 +155,8 @@ spec:
                           - name
                           type: object
                         throughputReservationSelector:
-                          description: Selector for a LiteReservation to populate
-                            throughputReservation.
+                          description: Selector for a LiteReservation in pubsub to
+                            populate throughputReservation.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -284,8 +284,8 @@ spec:
                             capacity.
                           type: string
                         throughputReservationRef:
-                          description: Reference to a LiteReservation to populate
-                            throughputReservation.
+                          description: Reference to a LiteReservation in pubsub to
+                            populate throughputReservation.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -319,8 +319,8 @@ spec:
                           - name
                           type: object
                         throughputReservationSelector:
-                          description: Selector for a LiteReservation to populate
-                            throughputReservation.
+                          description: Selector for a LiteReservation in pubsub to
+                            populate throughputReservation.
                           properties:
                             matchControllerRef:
                               description: |-

--- a/package/crds/pubsub.gcp.upbound.io_subscriptioniammembers.yaml
+++ b/package/crds/pubsub.gcp.upbound.io_subscriptioniammembers.yaml
@@ -93,7 +93,8 @@ spec:
                   subscription:
                     type: string
                   subscriptionRef:
-                    description: Reference to a Subscription to populate subscription.
+                    description: Reference to a Subscription in pubsub to populate
+                      subscription.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -127,7 +128,8 @@ spec:
                     - name
                     type: object
                   subscriptionSelector:
-                    description: Selector for a Subscription to populate subscription.
+                    description: Selector for a Subscription in pubsub to populate
+                      subscription.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -200,7 +202,8 @@ spec:
                   subscription:
                     type: string
                   subscriptionRef:
-                    description: Reference to a Subscription to populate subscription.
+                    description: Reference to a Subscription in pubsub to populate
+                      subscription.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -234,7 +237,8 @@ spec:
                     - name
                     type: object
                   subscriptionSelector:
-                    description: Selector for a Subscription to populate subscription.
+                    description: Selector for a Subscription in pubsub to populate
+                      subscription.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/pubsub.gcp.upbound.io_subscriptions.yaml
+++ b/package/crds/pubsub.gcp.upbound.io_subscriptions.yaml
@@ -462,7 +462,7 @@ spec:
                       the topic is in the same project as the subscription.
                     type: string
                   topicRef:
-                    description: Reference to a Topic to populate topic.
+                    description: Reference to a Topic in pubsub to populate topic.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -496,7 +496,7 @@ spec:
                     - name
                     type: object
                   topicSelector:
-                    description: Selector for a Topic to populate topic.
+                    description: Selector for a Topic in pubsub to populate topic.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -937,7 +937,7 @@ spec:
                       the topic is in the same project as the subscription.
                     type: string
                   topicRef:
-                    description: Reference to a Topic to populate topic.
+                    description: Reference to a Topic in pubsub to populate topic.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -971,7 +971,7 @@ spec:
                     - name
                     type: object
                   topicSelector:
-                    description: Selector for a Topic to populate topic.
+                    description: Selector for a Topic in pubsub to populate topic.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/pubsub.gcp.upbound.io_topiciammembers.yaml
+++ b/package/crds/pubsub.gcp.upbound.io_topiciammembers.yaml
@@ -93,7 +93,7 @@ spec:
                   topic:
                     type: string
                   topicRef:
-                    description: Reference to a Topic to populate topic.
+                    description: Reference to a Topic in pubsub to populate topic.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -127,7 +127,7 @@ spec:
                     - name
                     type: object
                   topicSelector:
-                    description: Selector for a Topic to populate topic.
+                    description: Selector for a Topic in pubsub to populate topic.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -200,7 +200,7 @@ spec:
                   topic:
                     type: string
                   topicRef:
-                    description: Reference to a Topic to populate topic.
+                    description: Reference to a Topic in pubsub to populate topic.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -234,7 +234,7 @@ spec:
                     - name
                     type: object
                   topicSelector:
-                    description: Selector for a Topic to populate topic.
+                    description: Selector for a Topic in pubsub to populate topic.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/secretmanager.gcp.upbound.io_secretiammembers.yaml
+++ b/package/crds/secretmanager.gcp.upbound.io_secretiammembers.yaml
@@ -93,7 +93,8 @@ spec:
                   secretId:
                     type: string
                   secretIdRef:
-                    description: Reference to a Secret to populate secretId.
+                    description: Reference to a Secret in secretmanager to populate
+                      secretId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -127,7 +128,8 @@ spec:
                     - name
                     type: object
                   secretIdSelector:
-                    description: Selector for a Secret to populate secretId.
+                    description: Selector for a Secret in secretmanager to populate
+                      secretId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -200,7 +202,8 @@ spec:
                   secretId:
                     type: string
                   secretIdRef:
-                    description: Reference to a Secret to populate secretId.
+                    description: Reference to a Secret in secretmanager to populate
+                      secretId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -234,7 +237,8 @@ spec:
                     - name
                     type: object
                   secretIdSelector:
-                    description: Selector for a Secret to populate secretId.
+                    description: Selector for a Secret in secretmanager to populate
+                      secretId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/secretmanager.gcp.upbound.io_secretversions.yaml
+++ b/package/crds/secretmanager.gcp.upbound.io_secretversions.yaml
@@ -107,7 +107,8 @@ spec:
                     - namespace
                     type: object
                   secretRef:
-                    description: Reference to a Secret to populate secret.
+                    description: Reference to a Secret in secretmanager to populate
+                      secret.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -141,7 +142,8 @@ spec:
                     - name
                     type: object
                   secretSelector:
-                    description: Selector for a Secret to populate secret.
+                    description: Selector for a Secret in secretmanager to populate
+                      secret.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -211,7 +213,8 @@ spec:
                     description: Secret Manager secret resource
                     type: string
                   secretRef:
-                    description: Reference to a Secret to populate secret.
+                    description: Reference to a Secret in secretmanager to populate
+                      secret.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -245,7 +248,8 @@ spec:
                     - name
                     type: object
                   secretSelector:
-                    description: Selector for a Secret to populate secret.
+                    description: Selector for a Secret in secretmanager to populate
+                      secret.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/sourcerepo.gcp.upbound.io_repositoryiammembers.yaml
+++ b/package/crds/sourcerepo.gcp.upbound.io_repositoryiammembers.yaml
@@ -91,7 +91,8 @@ spec:
                   repository:
                     type: string
                   repositoryRef:
-                    description: Reference to a Repository to populate repository.
+                    description: Reference to a Repository in sourcerepo to populate
+                      repository.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -125,7 +126,8 @@ spec:
                     - name
                     type: object
                   repositorySelector:
-                    description: Selector for a Repository to populate repository.
+                    description: Selector for a Repository in sourcerepo to populate
+                      repository.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -198,7 +200,8 @@ spec:
                   repository:
                     type: string
                   repositoryRef:
-                    description: Reference to a Repository to populate repository.
+                    description: Reference to a Repository in sourcerepo to populate
+                      repository.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -232,7 +235,8 @@ spec:
                     - name
                     type: object
                   repositorySelector:
-                    description: Selector for a Repository to populate repository.
+                    description: Selector for a Repository in sourcerepo to populate
+                      repository.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/spanner.gcp.upbound.io_databaseiammembers.yaml
+++ b/package/crds/spanner.gcp.upbound.io_databaseiammembers.yaml
@@ -87,7 +87,7 @@ spec:
                   database:
                     type: string
                   databaseRef:
-                    description: Reference to a Database to populate database.
+                    description: Reference to a Database in spanner to populate database.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -121,7 +121,7 @@ spec:
                     - name
                     type: object
                   databaseSelector:
-                    description: Selector for a Database to populate database.
+                    description: Selector for a Database in spanner to populate database.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -163,7 +163,7 @@ spec:
                   instance:
                     type: string
                   instanceRef:
-                    description: Reference to a Instance to populate instance.
+                    description: Reference to a Instance in spanner to populate instance.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -197,7 +197,7 @@ spec:
                     - name
                     type: object
                   instanceSelector:
-                    description: Selector for a Instance to populate instance.
+                    description: Selector for a Instance in spanner to populate instance.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -270,7 +270,7 @@ spec:
                   database:
                     type: string
                   databaseRef:
-                    description: Reference to a Database to populate database.
+                    description: Reference to a Database in spanner to populate database.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -304,7 +304,7 @@ spec:
                     - name
                     type: object
                   databaseSelector:
-                    description: Selector for a Database to populate database.
+                    description: Selector for a Database in spanner to populate database.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -346,7 +346,7 @@ spec:
                   instance:
                     type: string
                   instanceRef:
-                    description: Reference to a Instance to populate instance.
+                    description: Reference to a Instance in spanner to populate instance.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -380,7 +380,7 @@ spec:
                     - name
                     type: object
                   instanceSelector:
-                    description: Selector for a Instance to populate instance.
+                    description: Selector for a Instance in spanner to populate instance.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/spanner.gcp.upbound.io_instanceiammembers.yaml
+++ b/package/crds/spanner.gcp.upbound.io_instanceiammembers.yaml
@@ -87,7 +87,7 @@ spec:
                   instance:
                     type: string
                   instanceRef:
-                    description: Reference to a Instance to populate instance.
+                    description: Reference to a Instance in spanner to populate instance.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -121,7 +121,7 @@ spec:
                     - name
                     type: object
                   instanceSelector:
-                    description: Selector for a Instance to populate instance.
+                    description: Selector for a Instance in spanner to populate instance.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -194,7 +194,7 @@ spec:
                   instance:
                     type: string
                   instanceRef:
-                    description: Reference to a Instance to populate instance.
+                    description: Reference to a Instance in spanner to populate instance.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -228,7 +228,7 @@ spec:
                     - name
                     type: object
                   instanceSelector:
-                    description: Selector for a Instance to populate instance.
+                    description: Selector for a Instance in spanner to populate instance.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/sql.gcp.upbound.io_databases.yaml
+++ b/package/crds/sql.gcp.upbound.io_databases.yaml
@@ -102,7 +102,8 @@ spec:
                       ID.
                     type: string
                   instanceRef:
-                    description: Reference to a DatabaseInstance to populate instance.
+                    description: Reference to a DatabaseInstance in sql to populate
+                      instance.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -136,7 +137,8 @@ spec:
                     - name
                     type: object
                   instanceSelector:
-                    description: Selector for a DatabaseInstance to populate instance.
+                    description: Selector for a DatabaseInstance in sql to populate
+                      instance.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/sql.gcp.upbound.io_sslcerts.yaml
+++ b/package/crds/sql.gcp.upbound.io_sslcerts.yaml
@@ -84,7 +84,8 @@ spec:
                       forces a new resource to be created.
                     type: string
                   instanceRef:
-                    description: Reference to a DatabaseInstance to populate instance.
+                    description: Reference to a DatabaseInstance in sql to populate
+                      instance.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -118,7 +119,8 @@ spec:
                     - name
                     type: object
                   instanceSelector:
-                    description: Selector for a DatabaseInstance to populate instance.
+                    description: Selector for a DatabaseInstance in sql to populate
+                      instance.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -187,7 +189,8 @@ spec:
                       forces a new resource to be created.
                     type: string
                   instanceRef:
-                    description: Reference to a DatabaseInstance to populate instance.
+                    description: Reference to a DatabaseInstance in sql to populate
+                      instance.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -221,7 +224,8 @@ spec:
                     - name
                     type: object
                   instanceSelector:
-                    description: Selector for a DatabaseInstance to populate instance.
+                    description: Selector for a DatabaseInstance in sql to populate
+                      instance.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/sql.gcp.upbound.io_users.yaml
+++ b/package/crds/sql.gcp.upbound.io_users.yaml
@@ -91,7 +91,8 @@ spec:
                       forces a new resource to be created.
                     type: string
                   instanceRef:
-                    description: Reference to a DatabaseInstance to populate instance.
+                    description: Reference to a DatabaseInstance in sql to populate
+                      instance.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -125,7 +126,8 @@ spec:
                     - name
                     type: object
                   instanceSelector:
-                    description: Selector for a DatabaseInstance to populate instance.
+                    description: Selector for a DatabaseInstance in sql to populate
+                      instance.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -250,7 +252,8 @@ spec:
                       forces a new resource to be created.
                     type: string
                   instanceRef:
-                    description: Reference to a DatabaseInstance to populate instance.
+                    description: Reference to a DatabaseInstance in sql to populate
+                      instance.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -284,7 +287,8 @@ spec:
                     - name
                     type: object
                   instanceSelector:
-                    description: Selector for a DatabaseInstance to populate instance.
+                    description: Selector for a DatabaseInstance in sql to populate
+                      instance.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/storage.gcp.upbound.io_bucketiammembers.yaml
+++ b/package/crds/storage.gcp.upbound.io_bucketiammembers.yaml
@@ -76,7 +76,7 @@ spec:
                   bucket:
                     type: string
                   bucketRef:
-                    description: Reference to a Bucket to populate bucket.
+                    description: Reference to a Bucket in storage to populate bucket.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -110,7 +110,7 @@ spec:
                     - name
                     type: object
                   bucketSelector:
-                    description: Selector for a Bucket to populate bucket.
+                    description: Selector for a Bucket in storage to populate bucket.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -181,7 +181,7 @@ spec:
                   bucket:
                     type: string
                   bucketRef:
-                    description: Reference to a Bucket to populate bucket.
+                    description: Reference to a Bucket in storage to populate bucket.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -215,7 +215,7 @@ spec:
                     - name
                     type: object
                   bucketSelector:
-                    description: Selector for a Bucket to populate bucket.
+                    description: Selector for a Bucket in storage to populate bucket.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/storage.gcp.upbound.io_bucketobjects.yaml
+++ b/package/crds/storage.gcp.upbound.io_bucketobjects.yaml
@@ -77,7 +77,7 @@ spec:
                     description: The name of the containing bucket.
                     type: string
                   bucketRef:
-                    description: Reference to a Bucket to populate bucket.
+                    description: Reference to a Bucket in storage to populate bucket.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -111,7 +111,7 @@ spec:
                     - name
                     type: object
                   bucketSelector:
-                    description: Selector for a Bucket to populate bucket.
+                    description: Selector for a Bucket in storage to populate bucket.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -280,7 +280,7 @@ spec:
                     description: The name of the containing bucket.
                     type: string
                   bucketRef:
-                    description: Reference to a Bucket to populate bucket.
+                    description: Reference to a Bucket in storage to populate bucket.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -314,7 +314,7 @@ spec:
                     - name
                     type: object
                   bucketSelector:
-                    description: Selector for a Bucket to populate bucket.
+                    description: Selector for a Bucket in storage to populate bucket.
                     properties:
                       matchControllerRef:
                         description: |-


### PR DESCRIPTION
### Description of your changes


This PR changes the `Reference.Type` API with `Reference.TerraformName`. This change is necessary to support the multiversion APIs.

The reference configuration API in upjet includes a `Type` field that identifies the target reference field through the Kubernetes `Kind`. When you configure a reference field using this `Type` API, it searches for the target reference resource in the same API version. However, if the specific API version lacks the target reference resource, the reference cannot be resolved. To address this, we will use the `TerraformName` API for configuring cross-resource references. This API allows the reference resolver to locate the target reference resource across its latest available version.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Tested locally.

[contribution process]: https://git.io/fj2m9
