### PR TITLE
Update trivy scan workflow and scan config packages

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -22,7 +22,7 @@ permissions:
 env:
   SUPPORTED_RELEASES_NUMBER: '1'
   # comma separated list of images, without tag
-  IMAGES: "xpkg.upbound.io/upbound/provider-gcp"
+  IMAGES: "xpkg.upbound.io/upbound/provider-family-gcp"
 
 jobs:
   setup-vars:


### PR DESCRIPTION
### Description of your changes

After stopping the support to the monolithic packages, our scan workflows [fails](https://github.com/crossplane-contrib/provider-upjet-gcp/actions/runs/9901939808/job/27355082577). 
In this PR, the monolithic package in the workflow has been replaced with the config package.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR if necessary.~

### How has this code been tested

NA

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
