### PR TITLE
Switch to the new API for marking as required the `region` field of the Cloud Function resource

### DIFF
--- a/config/cloudfunctions/config.go
+++ b/config/cloudfunctions/config.go
@@ -22,7 +22,7 @@ func Configure(p *config.Provider) {
 			Schema["build_environment_variables"].Elem = schema.TypeString
 		r.TerraformResource.
 			Schema["environment_variables"].Elem = schema.TypeString
-		config.MarkAsRequired(r.TerraformResource, "region")
+		r.MarkAsRequired("region")
 	})
 
 	p.AddResourceConfigurator("google_cloudfunctions_function_iam_binding", func(r *config.Resource) {


### PR DESCRIPTION
### Description of your changes

This PR switches to the [new `config.Resource.MarkAsRequired`](https://github.com/sergenyalcin/upjet/blob/845dbf6b1b11cdcc329cea004fc29e2d23c5343b/pkg/config/common.go#L129) to mark as required the `region` field of the Cloud Function resource.

Fixes #575 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
