### PR TITLE
feat(uptest): make projectID configurable for local tests in other projects

### DIFF
--- a/cluster/test/setup.sh
+++ b/cluster/test/setup.sh
@@ -5,6 +5,8 @@ set -aeuo pipefail
 #
 # SPDX-License-Identifier: Apache-2.0
 
+UPTEST_GCP_PROJECT=${UPTEST_GCP_PROJECT:-official-provider-testing}
+
 echo "Running setup.sh"
 
 if [[ -n "${UPTEST_CLOUD_CREDENTIALS:-}" ]]; then
@@ -18,7 +20,7 @@ kind: ProviderConfig
 metadata:
   name: default
 spec:
-  projectID: official-provider-testing
+  projectID: ${UPTEST_GCP_PROJECT}
   credentials:
     source: Secret
     secretRef:


### PR DESCRIPTION
<!--
Thank you for helping to improve Official GCP Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official GCP Provider pull request. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes
makes it possible to override the projectID for providerconfig, if people testing with other projects than "official-provider-testing"

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Official GCP Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

https://github.com/crossplane-contrib/provider-upjet-gcp/actions/runs/10059740882

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
