### PR TITLE
Fix NodePool.container update loop by ignoring empty diff for queued_provisioning

### DIFF
--- a/config/container/config.go
+++ b/config/container/config.go
@@ -151,6 +151,9 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 			if asDiff, ok := diff.Attributes["autoscaling.#"]; ok && asDiff.Old == "" && asDiff.New == "" {
 				delete(diff.Attributes, "autoscaling.#")
 			}
+			if qpDiff, ok := diff.Attributes["queued_provisioning.#"]; ok && qpDiff.Old == "" && qpDiff.New == "" {
+				delete(diff.Attributes, "queued_provisioning.#")
+			}
 			return diff, nil
 		}
 	})


### PR DESCRIPTION
### Description of your changes

The queued_provisioning field for container_node_pool was added to the TF provider in version 5.21.0, and pulled into the GCP provider in #553. It has introduced an update loop on NodePool due to constantly having a diff:
```
 "instanceDiff": "*terraform.InstanceDiff{mu:sync.Mutex{state:0, sema:0x0}, Attributes:map[string]*terraform.ResourceAttrDiff{\"queued_provisioning.#\":*terraform.ResourceAttrDiff{Old:\"\", New:\"\", NewComputed:true, NewRemoved:false, NewExtra:interface {}(nil), RequiresNew:true, Sensitive:false, Type:0x0}}, Destroy:false, DestroyDeposed:false, DestroyTainted:false, RawConfig:cty.NilVal, RawState:cty.NilVal, RawPlan:cty.NilVal, Meta:map[string]interface {}(nil)}"
```
 
This PR removes the attribute from the diff if Old and New are both "", as is already done for the placement_policy and autoscaling attributes.

Fixes: #570 (I think the comments in that issue are misleading, the original bug report is about the update loop, not the inability to use the field.)


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Run locally connected to a remote cluster, created new Cluster and NodePool.

[contribution process]: https://git.io/fj2m9
