### PR TITLE
No late initialize for container NodePool's node_count and initial_node_count 

### DIFF
--- a/apis/container/v1beta1/zz_nodepool_terraformed.go
+++ b/apis/container/v1beta1/zz_nodepool_terraformed.go
@@ -118,6 +118,8 @@ func (tr *NodePool) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("InitialNodeCount"))
+	opts = append(opts, resource.WithNameFilter("NodeCount"))
 	opts = append(opts, resource.WithNameFilter("Version"))
 
 	li := resource.NewGenericLateInitializer(opts...)

--- a/apis/container/v1beta2/zz_nodepool_terraformed.go
+++ b/apis/container/v1beta2/zz_nodepool_terraformed.go
@@ -118,6 +118,8 @@ func (tr *NodePool) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("InitialNodeCount"))
+	opts = append(opts, resource.WithNameFilter("NodeCount"))
 	opts = append(opts, resource.WithNameFilter("Version"))
 
 	li := resource.NewGenericLateInitializer(opts...)

--- a/config/container/config.go
+++ b/config/container/config.go
@@ -134,6 +134,8 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 		r.LateInitializer = config.LateInitializer{
 			IgnoredFields: []string{
 				"version",
+				"node_count",
+				"initial_node_count",
 			},
 		}
 		r.References["cluster"] = config.Reference{

--- a/config/container/config.go
+++ b/config/container/config.go
@@ -156,6 +156,10 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 			if qpDiff, ok := diff.Attributes["queued_provisioning.#"]; ok && qpDiff.Old == "" && qpDiff.New == "" {
 				delete(diff.Attributes, "queued_provisioning.#")
 			}
+			// Changes to actual node count can alter the value TF calculates for initial_node_count, resulting in
+			// errors as initial_node_count cannot be updated. TF docs suggest using lifecycle ignore_changes for this
+			// attribute.
+			delete(diff.Attributes, "initial_node_count")
 			return diff, nil
 		}
 	})

--- a/config/container/config.go
+++ b/config/container/config.go
@@ -156,10 +156,12 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 			if qpDiff, ok := diff.Attributes["queued_provisioning.#"]; ok && qpDiff.Old == "" && qpDiff.New == "" {
 				delete(diff.Attributes, "queued_provisioning.#")
 			}
-			// Changes to actual node count can alter the value TF calculates for initial_node_count, resulting in
-			// errors as initial_node_count cannot be updated. TF docs suggest using lifecycle ignore_changes for this
-			// attribute.
-			delete(diff.Attributes, "initial_node_count")
+			if incDiff, ok := diff.Attributes["initial_node_count"]; ok && incDiff.Old != "" {
+				// Changes to actual node count can alter the value TF calculates for initial_node_count, resulting in
+				// errors as initial_node_count cannot be updated. TF docs suggest using lifecycle ignore_changes for this
+				// attribute.
+				delete(diff.Attributes, "initial_node_count")
+			}
 			return diff, nil
 		}
 	})


### PR DESCRIPTION
### Description of your changes

In the gcp terraform provider there are two ways to configure the size of NodePools:
* initial_node_count specifies the initial size of the node pool, allowing the pool size to be controlled by the cluster autoscaler (or other tooling);
* node_count explicitly configures the size of the node pool, allowing TF to manage the size of the pool.

You cannot specify both when creating a node pool, but this is not (currently) validated by the TF provider when updating an existing node pool.

At present provider-gcp late initializes both properties, resulting in a spec with both values set. Not only would this not be valid for creating a new node pool, but in the case where the user explicitly set only the initial size the late initialization causes the provider to attempt to manage the ongoing size of the node pool as if the user had set node_count too, resulting in fights with the GKE cluster autoscaler, etc.

While this can be worked around by disabling LateInitialize in the managementPolicy, the current behaviour is undesirable and surprising to users as it effectively removes the distinction between the two ways to specify pool size.

The [TF docs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_node_pool#initial_node_count) also warn that the initial_node_count reported can change if node pools are resized, and suggests using a lifecycle block to ignore changes.

This PR removes both node_count and intial_node_count from late initialization, and ignores changes to the initial_node_count field.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Note: The TF provider calculates current node_count as `int(instances / AZs)`, so when testing it's necessary to resize the node pool by at least the number of AZs or the provider will not detect the change!

* Create new node pool with initial_node_count, resize via the console, provider does nothing.
* Create new node pool with node_count, resize via the console, provider resets to specified size.