### PR TITLE
README: make links point to gcp, not azure

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ GCP API.
 ## Getting Started
 
 Follow the quick start
-guide [here](https://marketplace.upbound.io/providers/upbound/provider-family-azure/latest/docs/quickstart).
+guide [here](https://marketplace.upbound.io/providers/upbound/provider-family-gcp/latest/docs/quickstart).
 
 You can find a detailed API reference for all the managed resources with examples in
-the [Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-family-azure/latest/managed-resources).
+the [Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-family-gcp/latest/managed-resources).
 
 For more information about monitoring the Upjet runtime, please
 see [Monitoring Guide](https://github.com/crossplane/upjet/blob/main/docs/monitoring.md)
@@ -48,7 +48,7 @@ for [adding new resources](https://github.com/crossplane/upjet/blob/main/docs/ad
 ## Getting help
 
 For filing bugs, suggesting improvements, or requesting new resources or features, please
-open an [issue](https://github.com/crossplane-contrib/provider-upjet-azure/issues/new/choose).
+open an [issue](https://github.com/crossplane-contrib/provider-upjet-gcp/issues/new/choose).
 
 For general help on using the provider consider asking the Crossplane community in the
 [#upjet-provider-gcp](https://crossplane.slack.com/archives/C05E7EVM459) channel in


### PR DESCRIPTION
<!--
Please read through https://git.io/fj2m9 if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Fixes links in README that point to the wrong thing.

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

This is a documentation-only change, so I don't think it's necessary to test it.

[contribution process]: https://git.io/fj2m9
