### PR TITLE
Revert "Fix goroutine leak when reconciling"

### DIFF
--- a/internal/clients/gcp.go
+++ b/internal/clients/gcp.go
@@ -161,7 +161,7 @@ func configureNoForkGCPClient(ctx context.Context, ps *terraform.Setup, p schema
 	// only once and using a pointer argument here will cause
 	// race conditions between resources referring to different
 	// ProviderConfigs.
-	diag := p.Configure(ctx, &tfsdk.ResourceConfig{
+	diag := p.Configure(context.WithoutCancel(ctx), &tfsdk.ResourceConfig{
 		Config: ps.Configuration,
 	})
 	if diag != nil && diag.HasError() {


### PR DESCRIPTION
### Description of your changes

This reverts commit 0927b1f82bb5ee29df4a647d4a985d874d73460e.

With the above-reverted change, we encountered issues creating and deleting some resources.
- `examples/cloudplatform/v1beta1/projectservice.yaml`
```
    message: 'async create failed: failed to create the resource: [{0 Error when reading
      or editing Project Service : Parent context of request project/official-provider-testing/services
      canceled  []}]'
```
- `examples/cloudplatform/v1beta1/projectiammember.yaml`
```
    message: 'create failed: async create failed: failed to create the resource: [{0
      Parent context of request iam-project-official-provider-testing modifyIamPolicy
      canceled  []}]'
```
- `examples/container/v1beta1/cluster.yaml`
```
    message: 'create failed: async create failed: cannot get connection details: cannot
      get additional connection details: endpoint: not a string'
```
```
    message: 'async delete failed: failed to delete the resource: [{0 Error waiting
      for deleting GKE cluster: error while retrieving operation: unable to finish
      polling, context has been cancelled  []}]'
```



Fixes https://github.com/crossplane-contrib/provider-upjet-gcp/issues/611

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

The above failed tests have been tested manually and with uptest:
- `examples/cloudplatform/v1beta1/projectservice.yaml`: https://github.com/crossplane-contrib/provider-upjet-gcp/actions/runs/10771811848
```
NAME                                                          SYNCED   READY   EXTERNAL-NAME                                          AGE
projectservice.cloudplatform.gcp.upbound.io/project-service   True     True    official-provider-testing/clouddeploy.googleapis.com   2m8s
```
- `examples/cloudplatform/v1beta1/projectiammember.yaml`: https://github.com/crossplane-contrib/provider-upjet-gcp/actions/runs/10771726984
```
NAME                                                                SYNCED   READY   EXTERNAL-NAME
                                                    AGE
projectiammember.cloudplatform.gcp.upbound.io/project-iam-member2   True     True    official-provider-testing/roles/viewer/serviceAccount:official-provider-testing-noop@
official-provider-testing.iam.gserviceaccount.com   2m25s
```
- `examples/container/v1beta1/cluster.yaml`: https://github.com/crossplane-contrib/provider-upjet-gcp/actions/runs/10771724541
```
NAME                                       SYNCED   READY   EXTERNAL-NAME   AGE
cluster.container.gcp.upbound.io/primary   True     True    primary         8m30s
```


[contribution process]: https://git.io/fj2m9
