### PR TITLE
Use different parameters name for auth and config group overrides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,12 @@ export XPKG_REG_ORGS_NO_PROMOTE := $(XPKG_REG_ORGS_NO_PROMOTE)
 export XPKG_DIR := $(XPKG_DIR)
 export XPKG_IGNORE := $(XPKG_IGNORE)
 
+CONFIG_CRD_GROUP = $(PROVIDER_NAME)
+PROVIDER_AUTH_GROUP = $(PROVIDER_NAME)
+
+export CONFIG_CRD_GROUP := $(CONFIG_CRD_GROUP)
+export PROVIDER_AUTH_GROUP := $(PROVIDER_AUTH_GROUP)
+
 -include build/makelib/xpkg.mk
 
 # ====================================================================================

--- a/cluster/images/provider-gcp/Makefile
+++ b/cluster/images/provider-gcp/Makefile
@@ -77,9 +77,9 @@ batch-process: $(UP)
 		--auth-ext $(XPKG_DIR)/auth.yaml \
 		--crd-root $(XPKG_DIR)/crds \
 		--ignore $(XPKG_IGNORE) \
-		--crd-group-override monolith=* --crd-group-override config=$(PROVIDER_NAME) \
+		--crd-group-override monolith=* --crd-group-override config=$(CONFIG_CRD_GROUP) \
 		--package-metadata-template $(XPKG_DIR)/crossplane.yaml.tmpl \
-		--template-var XpkgRegOrg=$(XPKG_REG_ORGS) --template-var DepConstraint="$(DEP_CONSTRAINT)" --template-var ProviderName=$(PROVIDER_NAME) \
+		--template-var XpkgRegOrg=$(XPKG_REG_ORGS) --template-var DepConstraint="$(DEP_CONSTRAINT)" --template-var ProviderName=$(PROVIDER_NAME) --template-var ProviderAuthGroup=$(PROVIDER_AUTH_GROUP) \
 		--concurrency $(CONCURRENCY) \
 		--push-retry 10 || $(FAIL)
 	@$(OK) Done processing smaller provider packages for: "$(SUBPACKAGES)"

--- a/package/crossplane.yaml.tmpl
+++ b/package/crossplane.yaml.tmpl
@@ -26,7 +26,7 @@ metadata:
       If you encounter an issue please reach out on support@upbound.io email
       address. This is a subpackage for the {{ .Service }} API group.
     friendly-name.meta.crossplane.io: Provider GCP ({{ .Service }})
-    auth.upbound.io/group: {{ .ProviderName }}.upbound.io
+    auth.upbound.io/group: {{ .ProviderAuthGroup }}.upbound.io
 spec:
 {{ if ne .Service "monolith" }}
   crossplane:


### PR DESCRIPTION
### Description of your changes

This PR introduces a change for parametrizing the auth group and config group overrides. uses different parameters name for auth and config group overrides. There is not a behavior change for the provider because the values are set to the same (PROVIDER_NAME). Now, the dependency between these fields were eliminated.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Tested locally.

[contribution process]: https://git.io/fj2m9
