### PR TITLE
Use commenter's repository permissions instead of author association

### DIFF
--- a/.github/workflows/uptest-trigger.yml
+++ b/.github/workflows/uptest-trigger.yml
@@ -12,19 +12,32 @@ env:
   GO_VERSION: "1.23"
 
 jobs:
-  debug:
+  check-permissions:
     runs-on: ubuntu-latest
+    outputs:
+      permission: ${{ steps.check-permissions.outputs.permission }}
     steps:
-      - name: Debug
+      - name: Get Commenter Permissions
+        id: check-permissions
         run: |
           echo "Trigger keyword: '/test-examples'"
           echo "Go version: ${{ env.GO_VERSION }}"
-          echo "github.event.comment.author_association: ${{ github.event.comment.author_association }}"
+
+          REPO=${{ github.repository }}
+          COMMENTER=${{ github.event.comment.user.login }}
+
+          # Fetch the commenter's repo-level permission grant
+          GRANTED=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/$REPO/collaborators/$COMMENTER/permission" | jq -r .permission)
+
+          # Make it accessible in the workflow via a job output -- cannot use env
+          echo "User $COMMENTER has $GRANTED permissions"
+          echo "permission=$GRANTED" >> "$GITHUB_OUTPUT"
 
   get-example-list:
-    if: ${{ (github.event.comment.author_association == 'OWNER' ) &&
-      github.event.issue.pull_request &&
-      contains(github.event.comment.body, '/test-examples' ) }}
+    needs: check-permissions
+    if: ${{ (needs.check-permissions.outputs.permission == 'admin' || needs.check-permissions.outputs.permission == 'write') && github.event.issue.pull_request != null && contains(github.event.comment.body, '/test-examples')}}
     runs-on: ubuntu-latest
     outputs:
       example_list: ${{ steps.get-example-list-name.outputs.example-list }}
@@ -79,11 +92,11 @@ jobs:
             -f context="Uptest-${{ steps.get-example-list-name.outputs.example-hash }}"
 
   uptest:
-    if: ${{ (github.event.comment.author_association == 'OWNER' ) &&
-      github.event.issue.pull_request &&
-      contains(github.event.comment.body, '/test-examples' ) }}
+    needs:
+      - check-permissions
+      - get-example-list
+    if: ${{ (needs.check-permissions.outputs.permission == 'admin' || needs.check-permissions.outputs.permission == 'write') && github.event.issue.pull_request != null && contains(github.event.comment.body, '/test-examples')}}
     runs-on: ubuntu-latest
-    needs: get-example-list
 
     steps:
       - name: Cleanup Disk


### PR DESCRIPTION
### Description of your changes

Determine appropriate access for comment-based workflow triggers based on the commenter's repository-level permission, rather than author association (which is a non-intuitive derivation based on membership in the GitHub organization in addition to repository-level permissions).

This aims to ensure trusted actors are able to run their e2e workflows in repositories they maintain, without necessarily requiring membership in the crossplane-contrib organization.

xref https://github.com/crossplane-contrib/provider-upjet-azuread/pull/208

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

Tested on given ref repository.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
