### PR TITLE
Workaround goroutine leak when reconciling

### DIFF
--- a/internal/clients/gcp.go
+++ b/internal/clients/gcp.go
@@ -151,6 +151,8 @@ func TerraformSetupBuilder(tfProvider *schema.Provider) terraform.SetupFn { //no
 			ps.Configuration[keyCredentials] = string(data)
 		}
 
+		// deliberately not using the caller context as context used to configure terraform is stored
+		// nolint:contextcheck
 		return ps, errors.Wrap(configureNoForkGCPClient(&ps, *tfProvider), "failed to configure the no-fork GCP client")
 	}
 }

--- a/internal/clients/gcp.go
+++ b/internal/clients/gcp.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
@@ -150,18 +151,30 @@ func TerraformSetupBuilder(tfProvider *schema.Provider) terraform.SetupFn { //no
 			ps.Configuration[keyCredentials] = string(data)
 		}
 
-		return ps, errors.Wrap(configureNoForkGCPClient(ctx, &ps, *tfProvider), "failed to configure the no-fork GCP client")
+		return ps, errors.Wrap(configureNoForkGCPClient(&ps, *tfProvider), "failed to configure the no-fork GCP client")
 	}
 }
 
-func configureNoForkGCPClient(ctx context.Context, ps *terraform.Setup, p schema.Provider) error {
+func configureNoForkGCPClient(ps *terraform.Setup, p schema.Provider) error {
 	// Please be aware that this implementation relies on the schema.Provider
 	// parameter `p` being a non-pointer. This is because normally
 	// the Terraform plugin SDK normally configures the provider
 	// only once and using a pointer argument here will cause
 	// race conditions between resources referring to different
 	// ProviderConfigs.
-	diag := p.Configure(context.WithoutCancel(ctx), &tfsdk.ResourceConfig{
+
+	// Terraform provider stores the context used for its configuration
+	// - the context needs to stay active for a longer period of time than terraform plugin sdk operations
+	// - the context needs to be eventually cancelled otherwise google provider resources are leaked
+	const (
+		terraformPluginSDKAsyncTimeout = time.Hour
+		gracePeriod                    = 10 * time.Minute
+		providerTimeout                = terraformPluginSDKAsyncTimeout + gracePeriod
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	time.AfterFunc(providerTimeout, cancel)
+
+	diag := p.Configure(ctx, &tfsdk.ResourceConfig{
 		Config: ps.Configuration,
 	})
 	if diag != nil && diag.HasError() {


### PR DESCRIPTION
This patch fixes goroutine leak when reconciling in a way that work around early cancelation issues.

- the context used to configure the provider needs to be eventually done, otherwise an internal terraform provider cleanup goroutine is leaked
- on the other hand it needs to outlive the operations terraform plugin client perform async

Considered a workaround as there is no explicit or visible link to terraform async connector nor terraform provider



<!--
Please read through https://git.io/fj2m9 if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes


`terraform.SetupFn` is used by the upject async terraform plugin

- whichever context is given to `terraform.SetupFn` is **_stored_** in the meta field of `terraform.Setup` resulting from the configuration of the [terraform provider](https://github.com/hashicorp/terraform-provider-google/blob/d8d1db3267423af8b1fd1485bdbe22f5ff574e87/google/transport/config.go#L237)
- `terraform.SetupFn` is called to [synchronously to connect](https://github.com/crossplane/upjet/blob/ae37e28e15d96cb2630d7c666e8ceaff774e0a2f/pkg/controller/external_async_tfpluginfw.go#L55), ie during each reconciliation. The result is [stored to be reused](https://github.com/crossplane/upjet/blob/ae37e28e15d96cb2630d7c666e8ceaff774e0a2f/pkg/controller/external_tfpluginsdk.go#L114)
- the result `terraform.Setup` is later reused in asynchronous function [create](https://github.com/crossplane/upjet/blob/ae37e28e15d96cb2630d7c666e8ceaff774e0a2f/pkg/controller/external_async_tfpluginfw.go#L161) , [Update](https://github.com/crossplane/upjet/blob/ae37e28e15d96cb2630d7c666e8ceaff774e0a2f/pkg/controller/external_async_tfpluginfw.go#L194) or [Delete](https://github.com/crossplane/upjet/blob/ae37e28e15d96cb2630d7c666e8ceaff774e0a2f/pkg/controller/external_async_tfpluginfw.go#L227), with a total async timeout of one hour. When used, it relies on the stored context for all API calls to gcp.
- [As found by @lxDay](https://github.com/crossplane-contrib/provider-upjet-gcp/pull/539#issue-2343804409), an [internal go routine in the terraform provider is waiting indefinitely on the completion of the context used to configure it](https://github.com/hashicorp/terraform-provider-google/blob/1d1a50adf64af60815b7a08ffc5e9d3e856d2e9c/google/transport/batcher.go#L117-L123)

This pull request make sure the context outlive the async context.


<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Fixes #538 

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
