### PR TITLE
Update go version to 1.23.8 [Security]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/upbound/provider-gcp
 
-go 1.23.6
+go 1.23.8
 
 require (
 	dario.cat/mergo v1.0.0


### PR DESCRIPTION
### Description of your changes

This PR updates the go version to 1.23.8 for the following CVE:
```
NAME                 INSTALLED  FIXED-IN        TYPE       VULNERABILITY        SEVERITY
stdlib               go1.23.6   1.23.8, 1.24.2  go-module  CVE-2025-22871       Critical
```
I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

https://github.com/crossplane-contrib/provider-upjet-gcp/actions/runs/14878644315

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
