### PR TITLE
feat: redis instance - Store serverCaCerts.[].cert to connection details

### DIFF
--- a/config/cluster/redis/config.go
+++ b/config/cluster/redis/config.go
@@ -13,37 +13,53 @@ import (
 // Configure configures individual resources by adding custom
 // ResourceConfigurators.
 func Configure(p *config.Provider) {
-	p.AddResourceConfigurator("google_redis_instance", func(r *config.Resource) {
-		config.MarkAsRequired(r.TerraformResource, "region")
-		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]any) (map[string][]byte, error) {
-			conn := map[string][]byte{}
-			if a, ok := attr["host"].(string); ok {
-				conn["host"] = []byte(a)
-			}
-			return conn, nil
-		}
-	})
+	p.AddResourceConfigurator("google_redis_instance", redisInstance)
+	p.AddResourceConfigurator("google_redis_cluster", redisCluster)
+}
 
-	p.AddResourceConfigurator("google_redis_cluster", func(r *config.Resource) {
-		r.MarkAsRequired("region")
-		r.UseAsync = true
-		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]any) (map[string][]byte, error) {
-			conn := map[string][]byte{}
-			if discoveryendpoints, ok := attr["discovery_endpoints"].([]any); ok {
-				for i, de := range discoveryendpoints {
-					if discoveryendpoints, ok := de.(map[string]any); ok && len(discoveryendpoints) > 0 {
-						if address, ok := discoveryendpoints["address"].(string); ok {
-							key := fmt.Sprintf("discovery_endpoints_%d_address", i)
-							conn[key] = []byte(address)
-						}
-						if port, ok := discoveryendpoints["port"].(float64); ok {
-							key := fmt.Sprintf("discovery_endpoints_%d_port", i)
-							conn[key] = []byte(fmt.Sprintf("%g", port))
-						}
+func redisInstance(r *config.Resource) {
+	config.MarkAsRequired(r.TerraformResource, "region")
+	r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]any) (map[string][]byte, error) {
+		conn := map[string][]byte{}
+		if host, ok := attr["host"].(string); ok {
+			conn["host"] = []byte(host)
+		}
+		if port, ok := attr["port"].(float64); ok {
+			conn["port"] = []byte(fmt.Sprintf("%g", port))
+		}
+		if caCerts, ok := attr["server_ca_certs"].([]any); ok {
+			for i, ca := range caCerts {
+				if caCerts, ok := ca.(map[string]any); ok && len(caCerts) > 0 {
+					if cert, ok := caCerts["cert"].(string); ok {
+						key := fmt.Sprintf("server_ca_certs_%d_cert", i)
+						conn[key] = []byte(cert)
 					}
 				}
 			}
-			return conn, nil
 		}
-	})
+		return conn, nil
+	}
+}
+
+func redisCluster(r *config.Resource) {
+	r.MarkAsRequired("region")
+	r.UseAsync = true
+	r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]any) (map[string][]byte, error) {
+		conn := map[string][]byte{}
+		if discoveryendpoints, ok := attr["discovery_endpoints"].([]any); ok {
+			for i, de := range discoveryendpoints {
+				if discoveryendpoints, ok := de.(map[string]any); ok && len(discoveryendpoints) > 0 {
+					if address, ok := discoveryendpoints["address"].(string); ok {
+						key := fmt.Sprintf("discovery_endpoints_%d_address", i)
+						conn[key] = []byte(address)
+					}
+					if port, ok := discoveryendpoints["port"].(float64); ok {
+						key := fmt.Sprintf("discovery_endpoints_%d_port", i)
+						conn[key] = []byte(fmt.Sprintf("%g", port))
+					}
+				}
+			}
+		}
+		return conn, nil
+	}
 }

--- a/config/namespaced/redis/config.go
+++ b/config/namespaced/redis/config.go
@@ -13,37 +13,53 @@ import (
 // Configure configures individual resources by adding custom
 // ResourceConfigurators.
 func Configure(p *config.Provider) {
-	p.AddResourceConfigurator("google_redis_instance", func(r *config.Resource) {
-		config.MarkAsRequired(r.TerraformResource, "region")
-		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]any) (map[string][]byte, error) {
-			conn := map[string][]byte{}
-			if a, ok := attr["host"].(string); ok {
-				conn["host"] = []byte(a)
-			}
-			return conn, nil
-		}
-	})
+	p.AddResourceConfigurator("google_redis_instance", redisInstance)
+	p.AddResourceConfigurator("google_redis_cluster", redisCluster)
+}
 
-	p.AddResourceConfigurator("google_redis_cluster", func(r *config.Resource) {
-		r.MarkAsRequired("region")
-		r.UseAsync = true
-		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]any) (map[string][]byte, error) {
-			conn := map[string][]byte{}
-			if discoveryendpoints, ok := attr["discovery_endpoints"].([]any); ok {
-				for i, de := range discoveryendpoints {
-					if discoveryendpoints, ok := de.(map[string]any); ok && len(discoveryendpoints) > 0 {
-						if address, ok := discoveryendpoints["address"].(string); ok {
-							key := fmt.Sprintf("discovery_endpoints_%d_address", i)
-							conn[key] = []byte(address)
-						}
-						if port, ok := discoveryendpoints["port"].(float64); ok {
-							key := fmt.Sprintf("discovery_endpoints_%d_port", i)
-							conn[key] = []byte(fmt.Sprintf("%g", port))
-						}
+func redisInstance(r *config.Resource) {
+	config.MarkAsRequired(r.TerraformResource, "region")
+	r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]any) (map[string][]byte, error) {
+		conn := map[string][]byte{}
+		if host, ok := attr["host"].(string); ok {
+			conn["host"] = []byte(host)
+		}
+		if port, ok := attr["port"].(float64); ok {
+			conn["port"] = []byte(fmt.Sprintf("%g", port))
+		}
+		if caCerts, ok := attr["server_ca_certs"].([]any); ok {
+			for i, ca := range caCerts {
+				if caCerts, ok := ca.(map[string]any); ok && len(caCerts) > 0 {
+					if cert, ok := caCerts["cert"].(string); ok {
+						key := fmt.Sprintf("server_ca_certs_%d_cert", i)
+						conn[key] = []byte(cert)
 					}
 				}
 			}
-			return conn, nil
 		}
-	})
+		return conn, nil
+	}
+}
+
+func redisCluster(r *config.Resource) {
+	r.MarkAsRequired("region")
+	r.UseAsync = true
+	r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]any) (map[string][]byte, error) {
+		conn := map[string][]byte{}
+		if discoveryendpoints, ok := attr["discovery_endpoints"].([]any); ok {
+			for i, de := range discoveryendpoints {
+				if discoveryendpoints, ok := de.(map[string]any); ok && len(discoveryendpoints) > 0 {
+					if address, ok := discoveryendpoints["address"].(string); ok {
+						key := fmt.Sprintf("discovery_endpoints_%d_address", i)
+						conn[key] = []byte(address)
+					}
+					if port, ok := discoveryendpoints["port"].(float64); ok {
+						key := fmt.Sprintf("discovery_endpoints_%d_port", i)
+						conn[key] = []byte(fmt.Sprintf("%g", port))
+					}
+				}
+			}
+		}
+		return conn, nil
+	}
 }

--- a/examples/cluster/redis/v1beta1/cluster.yaml
+++ b/examples/cluster/redis/v1beta1/cluster.yaml
@@ -9,7 +9,7 @@ metadata:
   name: cluster-ha
 spec:
   forProvider:
-    authorizationMode: AUTH_MODE_DISABLED
+    authorizationMode: AUTH_MODE_IAM_AUTH
     deletionProtectionEnabled: false
     nodeType: REDIS_SHARED_CORE_NANO
     pscConfigs:
@@ -21,9 +21,12 @@ spec:
     region: us-central1
     replicaCount: 1
     shardCount: 3
-    transitEncryptionMode: TRANSIT_ENCRYPTION_MODE_DISABLED
+    transitEncryptionMode: TRANSIT_ENCRYPTION_MODE_SERVER_AUTHENTICATION
     zoneDistributionConfig:
       mode: MULTI_ZONE
+  writeConnectionSecretToRef:
+    name: example-redis-cluster-secret
+    namespace: upbound-system
 
 ---
 

--- a/examples/namespaced/redis/v1beta1/cluster.yaml
+++ b/examples/namespaced/redis/v1beta1/cluster.yaml
@@ -10,7 +10,7 @@ metadata:
   namespace: upbound-system
 spec:
   forProvider:
-    authorizationMode: AUTH_MODE_DISABLED
+    authorizationMode: AUTH_MODE_IAM_AUTH
     deletionProtectionEnabled: false
     nodeType: REDIS_SHARED_CORE_NANO
     pscConfigs:
@@ -22,9 +22,13 @@ spec:
     region: us-central1
     replicaCount: 1
     shardCount: 3
-    transitEncryptionMode: TRANSIT_ENCRYPTION_MODE_DISABLED
+    transitEncryptionMode: TRANSIT_ENCRYPTION_MODE_SERVER_AUTHENTICATION
     zoneDistributionConfig:
       mode: MULTI_ZONE
+  writeConnectionSecretToRef:
+    name: example-redis-cluster-secret
+    namespace: upbound-system
+      
 ---
 apiVersion: compute.gcp.m.upbound.io/v1beta1
 kind: Network


### PR DESCRIPTION
### Description of your changes

This adds the _Server CA Cert_ and _port_ to _Connection Details_. 

Also change `redis/v1beta1/cluster.yaml` example to use TLS.

Fixes #429

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

Executed e2e test for Redis Instance and Cluster verifying the connection details secret.

Example:

```
$ kubectl get secrets -n upbound-system example-redis-instance-secret -o json | jq -r '.data["attribute.auth_string"]' | base64 -d
c3d0fb97-d407-424e-885e-655690889a15⏎
$ kubectl get secrets -n upbound-system example-redis-instance-secret -o json | jq -r '.data.server_ca_certs_0_cert' | base64 -d
-----BEGIN CERTIFICATE-----
MIID7TCCAtWgAwIBAgIBADANBgkqhkiG9w0BAQsFADCBhTEtMCsGA1UELhMkMTAy
ZjI4OGQtOTYwMC00MjFiLTkyMmMtZjU4N2IzNGIyYzQ0MTEwLwYDVQQDEyhHb29n
bGUgQ2xvdWQgTWVtb3J5c3RvcmUgUmVkaXMgU2VydmVyIENBMRQwEgYDVQQKEwtH
b29nbGUsIEluYzELMAkGA1UEBhMCVVMwHhcNMjUwNjI3MTE1MzIyWhcNMzUwNjI1
MTE1NDIyWjCBhTEtMCsGA1UELhMkMTAyZjI4OGQtOTYwMC00MjFiLTkyMmMtZjU4
N2IzNGIyYzQ0MTEwLwYDVQQDEyhHb29nbGUgQ2xvdWQgTWVtb3J5c3RvcmUgUmVk
aXMgU2VydmVyIENBMRQwEgYDVQQKEwtHb29nbGUsIEluYzELMAkGA1UEBhMCVVMw
ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDVORtqRAmnh0noIHVBl7uz
jW1+pY2x4tq+FWpVSeheBV/jlyrwKcRNXF3seAQlOGfihonMjzeycgioiDwhVTkP
ejEKCPHxo/PQ2b69S7+8hudR5VgM5HP6Q8eBrvT7voStwq3SO4jLkFXNrxvkdtZP
RwmCni0sGI1+Mlq/FzWof+YhsuHLKdr1ssQDkuq6mRbiMrawNzkQBhi91lLTygl6
by6u+/7/UwFSfodkLWJm2OAof1WdntOIaAlVH5mQ+wtrhoKNYorYhTaID66s3xdY
/QMGpJ3xQknuai14/ZTVrrXOciTrD2BMi7AWTOoj+9Zbt9pd/JQvQdXW7rebKSiB
AgMBAAGjZjBkMB8GA1UdIwQYMBaAFEhKE/ZlEezkPE7MWf38sauZJ0UNMBIGA1Ud
EwEB/wQIMAYBAf8CAQAwDgYDVR0PAQH/BAQDAgEGMB0GA1UdDgQWBBRIShP2ZRHs
5DxOzFn9/LGrmSdFDTANBgkqhkiG9w0BAQsFAAOCAQEAclBy/KGtIgMmz4kMCujL
9TUXWFTh5ilLtGvYNhWT5rxy/IFEdru5FU8lE8G4UkNt0ME+6U8ezgck0gnQ0sbu
2ies5ZMtMgh3ebQ3q6SjEURTCKl7s8wNFWpD7nCDsQ9X5Is9nOmO0qF6ETDNho22
GFiM3J6Nk5UwwW/vTTpJeJZDtOefttT0l3yJ0HatxX5080N4YKQC/9btKsIUbHIy
yZiWln9ztg0E5P8oFDcu91b9FCESrFYX+LK6OB7YKQAwFKlm2zh5MVbq9cIRkgbs
MaKpULGQhXwtkg0KP7WLDQrrHX+8D9PwYE/yQSTe12ybRbEzbFjczaWC8Azw3CsL
jw==
```