### PR TITLE
fix(cloudplatform): treat masked 403 on absent project as not found

### DIFF
--- a/config/cluster/cloudplatform/config.go
+++ b/config/cluster/cloudplatform/config.go
@@ -6,6 +6,7 @@ package cloudplatform
 
 import (
 	"encoding/base64"
+	"strings"
 
 	"github.com/crossplane/upjet/v2/pkg/config"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -26,6 +27,23 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("google_project", func(r *config.Resource) {
 		r.TerraformResource.Schema["org_id"].Description =
 			"The numeric ID of the organization this project belongs to."
+		// The GCP API returns an ambiguous HTTP 403 when the caller does
+		// not have permission to access the project, which is
+		// indistinguishable from the project not existing. The upstream
+		// provider discards the underlying *googleapi.Error in this case,
+		// and the Terraform provider's HandleNotFoundError only handles
+		// 404, so the initial observe call fails instead of recognizing
+		// the resource needs to be created.
+		// See: https://github.com/crossplane-contrib/provider-upjet-gcp/issues/977
+		origRead := r.TerraformResource.Read                                              //nolint:staticcheck // upstream resource uses deprecated Read field
+		r.TerraformResource.Read = func(d *schema.ResourceData, meta interface{}) error { //nolint:staticcheck // wrapping upstream's deprecated Read field
+			err := origRead(d, meta)
+			if err != nil && strings.Contains(err.Error(), "or it may not exist") {
+				d.SetId("")
+				return nil
+			}
+			return err
+		}
 	})
 	p.AddResourceConfigurator("google_project_default_service_accounts", func(r *config.Resource) {
 		r.References["project"] = config.Reference{

--- a/config/cluster/cloudplatform/config_test.go
+++ b/config/cluster/cloudplatform/config_test.go
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: CC0-1.0
+
+package cloudplatform
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestProjectReadWrapper(t *testing.T) {
+	type args struct {
+		origErr error
+		id      string
+	}
+	type want struct {
+		err error
+		id  string
+	}
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"AbsentProjectError": {
+			reason: "An ambiguous 403 indicating the project may not exist should clear the ID and return nil",
+			args: args{
+				origErr: errors.New(`the user does not have permission to access Project "my-project" or it may not exist`),
+				id:      "my-project",
+			},
+			want: want{
+				err: nil,
+				id:  "",
+			},
+		},
+		"OtherError": {
+			reason: "Other errors should be returned as-is without clearing the ID",
+			args: args{
+				origErr: errors.New("some other API error"),
+				id:      "my-project",
+			},
+			want: want{
+				err: cmpopts.AnyError,
+				id:  "my-project",
+			},
+		},
+		"NoError": {
+			reason: "A successful read should pass through without modification",
+			args: args{
+				origErr: nil,
+				id:      "my-project",
+			},
+			want: want{
+				err: nil,
+				id:  "my-project",
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			// Create a minimal schema.Resource to get a valid ResourceData.
+			r := &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"org_id": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+				},
+			}
+			d := r.TestResourceData()
+			d.SetId(tc.args.id)
+
+			// Build the wrapper the same way the configurator does.
+			origRead := func(d *schema.ResourceData, meta interface{}) error {
+				return tc.args.origErr
+			}
+			wrappedRead := func(d *schema.ResourceData, meta interface{}) error {
+				err := origRead(d, meta)
+				if err != nil && strings.Contains(err.Error(), "or it may not exist") {
+					d.SetId("")
+					return nil
+				}
+				return err
+			}
+
+			err := wrappedRead(d, nil)
+
+			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("%s\nwrappedRead(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.id, d.Id()); diff != "" {
+				t.Errorf("%s\nwrappedRead(...): -want ID, +got ID:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/config/namespaced/cloudplatform/config.go
+++ b/config/namespaced/cloudplatform/config.go
@@ -6,6 +6,7 @@ package cloudplatform
 
 import (
 	"encoding/base64"
+	"strings"
 
 	"github.com/crossplane/upjet/v2/pkg/config"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -26,6 +27,23 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("google_project", func(r *config.Resource) {
 		r.TerraformResource.Schema["org_id"].Description =
 			"The numeric ID of the organization this project belongs to."
+		// The GCP API returns an ambiguous HTTP 403 when the caller does
+		// not have permission to access the project, which is
+		// indistinguishable from the project not existing. The upstream
+		// provider discards the underlying *googleapi.Error in this case,
+		// and the Terraform provider's HandleNotFoundError only handles
+		// 404, so the initial observe call fails instead of recognizing
+		// the resource needs to be created.
+		// See: https://github.com/crossplane-contrib/provider-upjet-gcp/issues/977
+		origRead := r.TerraformResource.Read                                              //nolint:staticcheck // upstream resource uses deprecated Read field
+		r.TerraformResource.Read = func(d *schema.ResourceData, meta interface{}) error { //nolint:staticcheck // wrapping upstream's deprecated Read field
+			err := origRead(d, meta)
+			if err != nil && strings.Contains(err.Error(), "or it may not exist") {
+				d.SetId("")
+				return nil
+			}
+			return err
+		}
 	})
 	p.AddResourceConfigurator("google_project_default_service_accounts", func(r *config.Resource) {
 		r.References["project"] = config.Reference{

--- a/config/namespaced/cloudplatform/config_test.go
+++ b/config/namespaced/cloudplatform/config_test.go
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: CC0-1.0
+
+package cloudplatform
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestProjectReadWrapper(t *testing.T) {
+	type args struct {
+		origErr error
+		id      string
+	}
+	type want struct {
+		err error
+		id  string
+	}
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"AbsentProjectError": {
+			reason: "An ambiguous 403 indicating the project may not exist should clear the ID and return nil",
+			args: args{
+				origErr: errors.New(`the user does not have permission to access Project "my-project" or it may not exist`),
+				id:      "my-project",
+			},
+			want: want{
+				err: nil,
+				id:  "",
+			},
+		},
+		"OtherError": {
+			reason: "Other errors should be returned as-is without clearing the ID",
+			args: args{
+				origErr: errors.New("some other API error"),
+				id:      "my-project",
+			},
+			want: want{
+				err: cmpopts.AnyError,
+				id:  "my-project",
+			},
+		},
+		"NoError": {
+			reason: "A successful read should pass through without modification",
+			args: args{
+				origErr: nil,
+				id:      "my-project",
+			},
+			want: want{
+				err: nil,
+				id:  "my-project",
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			// Create a minimal schema.Resource to get a valid ResourceData.
+			r := &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"org_id": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+				},
+			}
+			d := r.TestResourceData()
+			d.SetId(tc.args.id)
+
+			// Build the wrapper the same way the configurator does.
+			origRead := func(d *schema.ResourceData, meta interface{}) error {
+				return tc.args.origErr
+			}
+			wrappedRead := func(d *schema.ResourceData, meta interface{}) error {
+				err := origRead(d, meta)
+				if err != nil && strings.Contains(err.Error(), "or it may not exist") {
+					d.SetId("")
+					return nil
+				}
+				return err
+			}
+
+			err := wrappedRead(d, nil)
+
+			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("%s\nwrappedRead(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.id, d.Id()); diff != "" {
+				t.Errorf("%s\nwrappedRead(...): -want ID, +got ID:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Google Resource Manager returns an ambiguous 403 for an absent project ID. The upstream Terraform provider converts it into a plain error and discards the googleapi.Error, so HandleNotFoundError never sees it and Observe fails permanently instead of proceeding to Create.

Apply the same Read wrapper pattern merged in #909.

Fixes #977

<!--
Please read through https://git.io/fj2m9 if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Fixes #

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
