### PR TITLE
Suppress `monitoring_config.enable_components` order-only diffs via CustomDiff

### DIFF
--- a/config/cluster/container/config.go
+++ b/config/cluster/container/config.go
@@ -169,7 +169,7 @@ func isEmptyNodeConfigKubeletCount(key string, ad *terraform.ResourceAttrDiff) b
 // because the underlying TF provider uses TypeList (order-sensitive) for this
 // field. We suppress the diff when the sorted old and new element sets are
 // identical, indicating no real change.
-func suppressEnableComponentsOrderDiff(diff *terraform.InstanceDiff) {
+func suppressEnableComponentsOrderDiff(diff *terraform.InstanceDiff) { //nolint:gocyclo // easier to follow as a unit
 	if diff == nil || diff.Attributes == nil {
 		return
 	}

--- a/config/cluster/container/config.go
+++ b/config/cluster/container/config.go
@@ -7,6 +7,8 @@ package container
 import (
 	"encoding/base64"
 	"net/url"
+	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -81,6 +83,7 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 			}
 			delete(diff.Attributes, "autopilot_cluster_policy_config.#")
 			dropEmptyKubeletConfigDiff(diff)
+			suppressEnableComponentsOrderDiff(diff)
 			return diff, nil
 		}
 	})
@@ -158,6 +161,66 @@ func isEmptyNodeConfigKubeletCount(key string, ad *terraform.ResourceAttrDiff) b
 	oldEmpty := ad.Old == "" || ad.Old == "0"
 	newEmpty := ad.New == "" || ad.New == "0"
 	return oldEmpty && newEmpty
+}
+
+// suppressEnableComponentsOrderDiff removes order-only diffs on
+// monitoring_config.0.enable_components. The GCP API may return components in
+// a different order than what was specified, which causes a perpetual diff
+// because the underlying TF provider uses TypeList (order-sensitive) for this
+// field. We suppress the diff when the sorted old and new element sets are
+// identical, indicating no real change.
+func suppressEnableComponentsOrderDiff(diff *terraform.InstanceDiff) {
+	if diff == nil || diff.Attributes == nil {
+		return
+	}
+
+	prefix := "monitoring_config.0.enable_components."
+	countKey := prefix + "#"
+
+	// Early exit: if the element count changed, it is a real diff.
+	if cd, ok := diff.Attributes[countKey]; ok && cd.Old != cd.New {
+		return
+	}
+
+	var oldVals, newVals []string
+	var indexedKeys []string
+	for key, ad := range diff.Attributes {
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		suffix := strings.TrimPrefix(key, prefix)
+		if suffix == "#" {
+			continue
+		}
+		if _, err := strconv.Atoi(suffix); err != nil {
+			continue
+		}
+		indexedKeys = append(indexedKeys, key)
+		oldVals = append(oldVals, ad.Old)
+		newVals = append(newVals, ad.New)
+	}
+
+	if len(indexedKeys) == 0 {
+		return
+	}
+
+	sort.Strings(oldVals)
+	sort.Strings(newVals)
+
+	if len(oldVals) != len(newVals) {
+		return
+	}
+	for i := range oldVals {
+		if oldVals[i] != newVals[i] {
+			return
+		}
+	}
+
+	// Pure reorder — remove from diff so no update is triggered.
+	for _, key := range indexedKeys {
+		delete(diff.Attributes, key)
+	}
+	delete(diff.Attributes, countKey)
 }
 
 // clusterConnectionDetails builds the kubeconfig published in the connection

--- a/config/cluster/container/config_test.go
+++ b/config/cluster/container/config_test.go
@@ -13,6 +13,103 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+func Test_suppressEnableComponentsOrderDiff(t *testing.T) {
+	type args struct {
+		diff *terraform.InstanceDiff
+	}
+	type want struct {
+		attributes map[string]*terraform.ResourceAttrDiff
+	}
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		"nil_diff": {
+			args: args{diff: nil},
+			want: want{attributes: nil},
+		},
+		"no_enable_components_keys": {
+			args: args{diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"node_count": {Old: "1", New: "2"},
+				},
+			}},
+			want: want{attributes: map[string]*terraform.ResourceAttrDiff{
+				"node_count": {Old: "1", New: "2"},
+			}},
+		},
+		"pure_reorder_with_count_key": {
+			args: args{diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"monitoring_config.0.enable_components.#": {Old: "2", New: "2"},
+					"monitoring_config.0.enable_components.0": {Old: "SYSTEM_COMPONENTS", New: "APISERVER"},
+					"monitoring_config.0.enable_components.1": {Old: "APISERVER", New: "SYSTEM_COMPONENTS"},
+				},
+			}},
+			want: want{attributes: map[string]*terraform.ResourceAttrDiff{}},
+		},
+		"pure_reorder_without_count_key": {
+			args: args{diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"monitoring_config.0.enable_components.0": {Old: "SYSTEM_COMPONENTS", New: "APISERVER"},
+					"monitoring_config.0.enable_components.1": {Old: "APISERVER", New: "SYSTEM_COMPONENTS"},
+				},
+			}},
+			want: want{attributes: map[string]*terraform.ResourceAttrDiff{}},
+		},
+		"real_change_element_replaced": {
+			args: args{diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"monitoring_config.0.enable_components.#": {Old: "2", New: "2"},
+					"monitoring_config.0.enable_components.0": {Old: "APISERVER", New: "WORKLOADS"},
+				},
+			}},
+			want: want{attributes: map[string]*terraform.ResourceAttrDiff{
+				"monitoring_config.0.enable_components.#": {Old: "2", New: "2"},
+				"monitoring_config.0.enable_components.0": {Old: "APISERVER", New: "WORKLOADS"},
+			}},
+		},
+		"real_change_count_increased": {
+			args: args{diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"monitoring_config.0.enable_components.#": {Old: "1", New: "2"},
+					"monitoring_config.0.enable_components.0": {Old: "SYSTEM_COMPONENTS", New: "SYSTEM_COMPONENTS"},
+					"monitoring_config.0.enable_components.1": {Old: "", New: "APISERVER"},
+				},
+			}},
+			want: want{attributes: map[string]*terraform.ResourceAttrDiff{
+				"monitoring_config.0.enable_components.#": {Old: "1", New: "2"},
+				"monitoring_config.0.enable_components.0": {Old: "SYSTEM_COMPONENTS", New: "SYSTEM_COMPONENTS"},
+				"monitoring_config.0.enable_components.1": {Old: "", New: "APISERVER"},
+			}},
+		},
+		"unrelated_keys_preserved_on_reorder": {
+			args: args{diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"node_count": {Old: "1", New: "2"},
+					"monitoring_config.0.enable_components.0": {Old: "SYSTEM_COMPONENTS", New: "APISERVER"},
+					"monitoring_config.0.enable_components.1": {Old: "APISERVER", New: "SYSTEM_COMPONENTS"},
+				},
+			}},
+			want: want{attributes: map[string]*terraform.ResourceAttrDiff{
+				"node_count": {Old: "1", New: "2"},
+			}},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			suppressEnableComponentsOrderDiff(tc.args.diff)
+			var gotAttrs map[string]*terraform.ResourceAttrDiff
+			if tc.args.diff != nil {
+				gotAttrs = tc.args.diff.Attributes
+			}
+			if diff := cmp.Diff(tc.want.attributes, gotAttrs); diff != "" {
+				t.Errorf("suppressEnableComponentsOrderDiff(...) attributes mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestDropEmptyKubeletConfigDiff(t *testing.T) {
 	cases := map[string]struct {
 		attrs   map[string]*terraform.ResourceAttrDiff

--- a/config/namespaced/container/config.go
+++ b/config/namespaced/container/config.go
@@ -169,7 +169,7 @@ func isEmptyNodeConfigKubeletCount(key string, ad *terraform.ResourceAttrDiff) b
 // because the underlying TF provider uses TypeList (order-sensitive) for this
 // field. We suppress the diff when the sorted old and new element sets are
 // identical, indicating no real change.
-func suppressEnableComponentsOrderDiff(diff *terraform.InstanceDiff) {
+func suppressEnableComponentsOrderDiff(diff *terraform.InstanceDiff) { //nolint:gocyclo // easier to follow as a unit
 	if diff == nil || diff.Attributes == nil {
 		return
 	}

--- a/config/namespaced/container/config.go
+++ b/config/namespaced/container/config.go
@@ -7,6 +7,8 @@ package container
 import (
 	"encoding/base64"
 	"net/url"
+	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -81,6 +83,7 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 			}
 			delete(diff.Attributes, "autopilot_cluster_policy_config.#")
 			dropEmptyKubeletConfigDiff(diff)
+			suppressEnableComponentsOrderDiff(diff)
 			return diff, nil
 		}
 	})
@@ -158,6 +161,66 @@ func isEmptyNodeConfigKubeletCount(key string, ad *terraform.ResourceAttrDiff) b
 	oldEmpty := ad.Old == "" || ad.Old == "0"
 	newEmpty := ad.New == "" || ad.New == "0"
 	return oldEmpty && newEmpty
+}
+
+// suppressEnableComponentsOrderDiff removes order-only diffs on
+// monitoring_config.0.enable_components. The GCP API may return components in
+// a different order than what was specified, which causes a perpetual diff
+// because the underlying TF provider uses TypeList (order-sensitive) for this
+// field. We suppress the diff when the sorted old and new element sets are
+// identical, indicating no real change.
+func suppressEnableComponentsOrderDiff(diff *terraform.InstanceDiff) {
+	if diff == nil || diff.Attributes == nil {
+		return
+	}
+
+	prefix := "monitoring_config.0.enable_components."
+	countKey := prefix + "#"
+
+	// Early exit: if the element count changed, it is a real diff.
+	if cd, ok := diff.Attributes[countKey]; ok && cd.Old != cd.New {
+		return
+	}
+
+	var oldVals, newVals []string
+	var indexedKeys []string
+	for key, ad := range diff.Attributes {
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		suffix := strings.TrimPrefix(key, prefix)
+		if suffix == "#" {
+			continue
+		}
+		if _, err := strconv.Atoi(suffix); err != nil {
+			continue
+		}
+		indexedKeys = append(indexedKeys, key)
+		oldVals = append(oldVals, ad.Old)
+		newVals = append(newVals, ad.New)
+	}
+
+	if len(indexedKeys) == 0 {
+		return
+	}
+
+	sort.Strings(oldVals)
+	sort.Strings(newVals)
+
+	if len(oldVals) != len(newVals) {
+		return
+	}
+	for i := range oldVals {
+		if oldVals[i] != newVals[i] {
+			return
+		}
+	}
+
+	// Pure reorder — remove from diff so no update is triggered.
+	for _, key := range indexedKeys {
+		delete(diff.Attributes, key)
+	}
+	delete(diff.Attributes, countKey)
 }
 
 // clusterConnectionDetails builds the kubeconfig published in the connection

--- a/config/namespaced/container/config_test.go
+++ b/config/namespaced/container/config_test.go
@@ -13,6 +13,103 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+func Test_suppressEnableComponentsOrderDiff(t *testing.T) {
+	type args struct {
+		diff *terraform.InstanceDiff
+	}
+	type want struct {
+		attributes map[string]*terraform.ResourceAttrDiff
+	}
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		"nil_diff": {
+			args: args{diff: nil},
+			want: want{attributes: nil},
+		},
+		"no_enable_components_keys": {
+			args: args{diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"node_count": {Old: "1", New: "2"},
+				},
+			}},
+			want: want{attributes: map[string]*terraform.ResourceAttrDiff{
+				"node_count": {Old: "1", New: "2"},
+			}},
+		},
+		"pure_reorder_with_count_key": {
+			args: args{diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"monitoring_config.0.enable_components.#": {Old: "2", New: "2"},
+					"monitoring_config.0.enable_components.0": {Old: "SYSTEM_COMPONENTS", New: "APISERVER"},
+					"monitoring_config.0.enable_components.1": {Old: "APISERVER", New: "SYSTEM_COMPONENTS"},
+				},
+			}},
+			want: want{attributes: map[string]*terraform.ResourceAttrDiff{}},
+		},
+		"pure_reorder_without_count_key": {
+			args: args{diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"monitoring_config.0.enable_components.0": {Old: "SYSTEM_COMPONENTS", New: "APISERVER"},
+					"monitoring_config.0.enable_components.1": {Old: "APISERVER", New: "SYSTEM_COMPONENTS"},
+				},
+			}},
+			want: want{attributes: map[string]*terraform.ResourceAttrDiff{}},
+		},
+		"real_change_element_replaced": {
+			args: args{diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"monitoring_config.0.enable_components.#": {Old: "2", New: "2"},
+					"monitoring_config.0.enable_components.0": {Old: "APISERVER", New: "WORKLOADS"},
+				},
+			}},
+			want: want{attributes: map[string]*terraform.ResourceAttrDiff{
+				"monitoring_config.0.enable_components.#": {Old: "2", New: "2"},
+				"monitoring_config.0.enable_components.0": {Old: "APISERVER", New: "WORKLOADS"},
+			}},
+		},
+		"real_change_count_increased": {
+			args: args{diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"monitoring_config.0.enable_components.#": {Old: "1", New: "2"},
+					"monitoring_config.0.enable_components.0": {Old: "SYSTEM_COMPONENTS", New: "SYSTEM_COMPONENTS"},
+					"monitoring_config.0.enable_components.1": {Old: "", New: "APISERVER"},
+				},
+			}},
+			want: want{attributes: map[string]*terraform.ResourceAttrDiff{
+				"monitoring_config.0.enable_components.#": {Old: "1", New: "2"},
+				"monitoring_config.0.enable_components.0": {Old: "SYSTEM_COMPONENTS", New: "SYSTEM_COMPONENTS"},
+				"monitoring_config.0.enable_components.1": {Old: "", New: "APISERVER"},
+			}},
+		},
+		"unrelated_keys_preserved_on_reorder": {
+			args: args{diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"node_count": {Old: "1", New: "2"},
+					"monitoring_config.0.enable_components.0": {Old: "SYSTEM_COMPONENTS", New: "APISERVER"},
+					"monitoring_config.0.enable_components.1": {Old: "APISERVER", New: "SYSTEM_COMPONENTS"},
+				},
+			}},
+			want: want{attributes: map[string]*terraform.ResourceAttrDiff{
+				"node_count": {Old: "1", New: "2"},
+			}},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			suppressEnableComponentsOrderDiff(tc.args.diff)
+			var gotAttrs map[string]*terraform.ResourceAttrDiff
+			if tc.args.diff != nil {
+				gotAttrs = tc.args.diff.Attributes
+			}
+			if diff := cmp.Diff(tc.want.attributes, gotAttrs); diff != "" {
+				t.Errorf("suppressEnableComponentsOrderDiff(...) attributes mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestDropEmptyKubeletConfigDiff(t *testing.T) {
 	cases := map[string]struct {
 		attrs   map[string]*terraform.ResourceAttrDiff


### PR DESCRIPTION
### Description of your changes

The GCP API returns `monitoring_config.enable_components` in a non-deterministic order. Because the underlying google provider declares this field as TypeList (order-sensitive), any order difference between the desired and observed state triggers a perpetual update loop.

This fix adds `suppressEnableComponentsOrderDiff` to the `TerraformCustomDiff` of `google_container_cluster` in both cluster and namespaced configs. It collects the old and new element values from the flat diff map, sorts both, and suppresses the diff when the sorted sets are identical — indicating a pure reorder with no real change.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

https://github.com/crossplane-contrib/provider-upjet-gcp/actions/runs/34203412331

Tested locally by applying the following manifest and validated the custom diff works properly.

```yaml
apiVersion: container.gcp.upbound.io/v1beta2
kind: Cluster
metadata:
  name: cluster-monitoring-repro
spec:
  forProvider:
    deletionProtection: false
    location: europe-west1
    initialNodeCount: 1
    monitoringConfig:
      enableComponents:
        - SYSTEM_COMPONENTS
        - CONTROLLER_MANAGER
        - SCHEDULER
        - APISERVER
```

[contribution process]: https://git.io/fj2m9
