### PR TITLE
fix(container): suppress perpetual upgrade_settings diff for flex-start/DWS pools (SHORT_LIVED)

### DIFF
--- a/config/cluster/container/config.go
+++ b/config/cluster/container/config.go
@@ -122,9 +122,35 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 				delete(diff.Attributes, "initial_node_count")
 			}
 			dropEmptyKubeletConfigDiff(diff)
+			suppressForcedShortLivedUpgradeDiff(diff)
 			return diff, nil
 		}
 	})
+}
+
+// suppressForcedShortLivedUpgradeDiff removes the perpetual no-op diff on
+// upgrade_settings for flex-start / QueuedProvisioning (DWS) node pools. GKE
+// forces strategy=SHORT_LIVED and max_surge=0 server-side on such pools, but
+// the underlying Terraform google provider schema for upgrade_settings.strategy
+// has Default:"SURGE" and a ValidateFunc that only accepts {"SURGE","BLUE_GREEN"}.
+// On every reconcile the spec-derived desired value becomes "SURGE" while the
+// observed value is "SHORT_LIVED", producing a diff that can never converge
+// (the value cannot be set to SHORT_LIVED, and it is not user-settable). We
+// suppress the strategy and max_surge diff entries only when the observed
+// (Old) strategy is SHORT_LIVED, i.e. GKE has forced it. Any real user change
+// (Old is SURGE or BLUE_GREEN) is left untouched.
+func suppressForcedShortLivedUpgradeDiff(diff *terraform.InstanceDiff) {
+	if diff == nil || diff.Attributes == nil {
+		return
+	}
+	sd, ok := diff.Attributes["upgrade_settings.0.strategy"]
+	if !ok || sd == nil || sd.Old != "SHORT_LIVED" {
+		return
+	}
+	delete(diff.Attributes, "upgrade_settings.0.strategy")
+	if msd, ok := diff.Attributes["upgrade_settings.0.max_surge"]; ok && msd != nil {
+		delete(diff.Attributes, "upgrade_settings.0.max_surge")
+	}
 }
 
 // dropEmptyKubeletConfigDiff removes empty node_config.*.kubelet_config block

--- a/config/cluster/container/config_test.go
+++ b/config/cluster/container/config_test.go
@@ -159,6 +159,57 @@ func TestDropEmptyKubeletConfigDiff(t *testing.T) {
 	}
 }
 
+func TestSuppressForcedShortLivedUpgradeDiff(t *testing.T) {
+	cases := map[string]struct {
+		attrs   map[string]*terraform.ResourceAttrDiff
+		dropped []string // keys expected to be removed
+		kept    []string // keys expected to remain
+	}{
+		"DropsGKEForcedShortLived": {
+			attrs: map[string]*terraform.ResourceAttrDiff{
+				"upgrade_settings.0.strategy":  {Old: "SHORT_LIVED", New: "SURGE"},
+				"upgrade_settings.0.max_surge": {Old: "0", New: "1"},
+			},
+			dropped: []string{"upgrade_settings.0.strategy", "upgrade_settings.0.max_surge"},
+		},
+		"KeepsRealSurgeToBlueGreenChange": {
+			attrs: map[string]*terraform.ResourceAttrDiff{
+				"upgrade_settings.0.strategy": {Old: "SURGE", New: "BLUE_GREEN"},
+			},
+			kept: []string{"upgrade_settings.0.strategy"},
+		},
+		"KeepsBlueGreenToSurgeChange": {
+			attrs: map[string]*terraform.ResourceAttrDiff{
+				"upgrade_settings.0.strategy":  {Old: "BLUE_GREEN", New: "SURGE"},
+				"upgrade_settings.0.max_surge": {Old: "0", New: "1"},
+			},
+			kept: []string{"upgrade_settings.0.strategy", "upgrade_settings.0.max_surge"},
+		},
+		"NoStrategyDiffLeavesMaxSurgeUntouched": {
+			attrs: map[string]*terraform.ResourceAttrDiff{
+				"upgrade_settings.0.max_surge": {Old: "0", New: "1"},
+			},
+			kept: []string{"upgrade_settings.0.max_surge"},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			diff := &terraform.InstanceDiff{Attributes: tc.attrs}
+			suppressForcedShortLivedUpgradeDiff(diff)
+			for _, k := range tc.dropped {
+				if _, ok := diff.Attributes[k]; ok {
+					t.Errorf("expected key %q to be dropped, but it remained", k)
+				}
+			}
+			for _, k := range tc.kept {
+				if _, ok := diff.Attributes[k]; !ok {
+					t.Errorf("expected key %q to be kept, but it was dropped", k)
+				}
+			}
+		})
+	}
+}
+
 func TestClusterConnectionDetails(t *testing.T) {
 	caPEM := []byte("-----BEGIN CERTIFICATE-----\nprivate-cluster-ca\n-----END CERTIFICATE-----")
 

--- a/config/namespaced/container/config.go
+++ b/config/namespaced/container/config.go
@@ -122,9 +122,35 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 				delete(diff.Attributes, "initial_node_count")
 			}
 			dropEmptyKubeletConfigDiff(diff)
+			suppressForcedShortLivedUpgradeDiff(diff)
 			return diff, nil
 		}
 	})
+}
+
+// suppressForcedShortLivedUpgradeDiff removes the perpetual no-op diff on
+// upgrade_settings for flex-start / QueuedProvisioning (DWS) node pools. GKE
+// forces strategy=SHORT_LIVED and max_surge=0 server-side on such pools, but
+// the underlying Terraform google provider schema for upgrade_settings.strategy
+// has Default:"SURGE" and a ValidateFunc that only accepts {"SURGE","BLUE_GREEN"}.
+// On every reconcile the spec-derived desired value becomes "SURGE" while the
+// observed value is "SHORT_LIVED", producing a diff that can never converge
+// (the value cannot be set to SHORT_LIVED, and it is not user-settable). We
+// suppress the strategy and max_surge diff entries only when the observed
+// (Old) strategy is SHORT_LIVED, i.e. GKE has forced it. Any real user change
+// (Old is SURGE or BLUE_GREEN) is left untouched.
+func suppressForcedShortLivedUpgradeDiff(diff *terraform.InstanceDiff) {
+	if diff == nil || diff.Attributes == nil {
+		return
+	}
+	sd, ok := diff.Attributes["upgrade_settings.0.strategy"]
+	if !ok || sd == nil || sd.Old != "SHORT_LIVED" {
+		return
+	}
+	delete(diff.Attributes, "upgrade_settings.0.strategy")
+	if msd, ok := diff.Attributes["upgrade_settings.0.max_surge"]; ok && msd != nil {
+		delete(diff.Attributes, "upgrade_settings.0.max_surge")
+	}
 }
 
 // dropEmptyKubeletConfigDiff removes empty node_config.*.kubelet_config block

--- a/config/namespaced/container/config_test.go
+++ b/config/namespaced/container/config_test.go
@@ -159,6 +159,57 @@ func TestDropEmptyKubeletConfigDiff(t *testing.T) {
 	}
 }
 
+func TestSuppressForcedShortLivedUpgradeDiff(t *testing.T) {
+	cases := map[string]struct {
+		attrs   map[string]*terraform.ResourceAttrDiff
+		dropped []string // keys expected to be removed
+		kept    []string // keys expected to remain
+	}{
+		"DropsGKEForcedShortLived": {
+			attrs: map[string]*terraform.ResourceAttrDiff{
+				"upgrade_settings.0.strategy":  {Old: "SHORT_LIVED", New: "SURGE"},
+				"upgrade_settings.0.max_surge": {Old: "0", New: "1"},
+			},
+			dropped: []string{"upgrade_settings.0.strategy", "upgrade_settings.0.max_surge"},
+		},
+		"KeepsRealSurgeToBlueGreenChange": {
+			attrs: map[string]*terraform.ResourceAttrDiff{
+				"upgrade_settings.0.strategy": {Old: "SURGE", New: "BLUE_GREEN"},
+			},
+			kept: []string{"upgrade_settings.0.strategy"},
+		},
+		"KeepsBlueGreenToSurgeChange": {
+			attrs: map[string]*terraform.ResourceAttrDiff{
+				"upgrade_settings.0.strategy":  {Old: "BLUE_GREEN", New: "SURGE"},
+				"upgrade_settings.0.max_surge": {Old: "0", New: "1"},
+			},
+			kept: []string{"upgrade_settings.0.strategy", "upgrade_settings.0.max_surge"},
+		},
+		"NoStrategyDiffLeavesMaxSurgeUntouched": {
+			attrs: map[string]*terraform.ResourceAttrDiff{
+				"upgrade_settings.0.max_surge": {Old: "0", New: "1"},
+			},
+			kept: []string{"upgrade_settings.0.max_surge"},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			diff := &terraform.InstanceDiff{Attributes: tc.attrs}
+			suppressForcedShortLivedUpgradeDiff(diff)
+			for _, k := range tc.dropped {
+				if _, ok := diff.Attributes[k]; ok {
+					t.Errorf("expected key %q to be dropped, but it remained", k)
+				}
+			}
+			for _, k := range tc.kept {
+				if _, ok := diff.Attributes[k]; !ok {
+					t.Errorf("expected key %q to be kept, but it was dropped", k)
+				}
+			}
+		})
+	}
+}
+
 func TestClusterConnectionDetails(t *testing.T) {
 	caPEM := []byte("-----BEGIN CERTIFICATE-----\nprivate-cluster-ca\n-----END CERTIFICATE-----")
 


### PR DESCRIPTION
## Description of your changes

Fixes #1028.

container `NodePool` resources for **flex-start / QueuedProvisioning (DWS)** pools enter a perpetual no-op update loop on `upgrade_settings`:

```
upgrade_settings.0.strategy   {Old:"SHORT_LIVED" New:"SURGE"}
upgrade_settings.0.max_surge  {Old:"0" New:"1"}
```

GKE forces `strategy=SHORT_LIVED, max_surge=0` server-side on these pools (`SHORT_LIVED` is the dedicated GKE upgrade strategy for QueuedProvisioning / flex-start pools). But the `upgrade_settings.strategy` schema has `Default:"SURGE"` and `ValidateFunc = StringInSlice({"SURGE","BLUE_GREEN"})`, so:

- the spec-derived desired value is always `SURGE` / `max_surge=1`, while observed is `SHORT_LIVED` / `max_surge=0`;
- `SHORT_LIVED` cannot be set to match (not in the enum, not user-settable);
- the diff never converges → perpetual reconcile (no effective GCP change; 0 `UpdateNodePool` operations observed over 90 days).

This is the same class as #1019/#1022: a non-convergent diff for a field whose server value falls outside the schema's accepted set.

### Fix

Add a `CustomizeDiff` (`suppressForcedShortLivedUpgradeDiff`) to the container NodePool config (both `config/cluster/container` and `config/namespaced/container`) that removes the `upgrade_settings.0.strategy` and `upgrade_settings.0.max_surge` diff entries **only when the observed (Old) strategy is `SHORT_LIVED`** — i.e. GKE has forced it. Real user changes (Old `SURGE`/`BLUE_GREEN`) are left untouched.

## I have:

- [x] Read and followed the [contribution process](https://github.com/crossplane/crossplane/blob/master/CONTRIBUTING.md).
- [x] Added or updated unit tests (`TestSuppressForcedShortLivedUpgradeDiff`, cluster + namespaced).
- [x] Run `go test ./config/cluster/container/... ./config/namespaced/container/...` — passing.

## How has this code been tested

Unit tests cover: GKE-forced `SHORT_LIVED→SURGE` (dropped), real `SURGE→BLUE_GREEN` (kept), `BLUE_GREEN→SURGE` (kept), and `max_surge`-only with no strategy diff (kept).

Behaviour verified against live managers (v2.6.0 and v3.0.0) where flex/DWS pools show the perpetual `SHORT_LIVED→SURGE` diff; the CustomizeDiff removes it while leaving genuine strategy changes intact.
